### PR TITLE
feat(ui): dashboard redesign & layout consistency

### DIFF
--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -4,7 +4,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { useHostStore, useSessionStore, useUIStore, useSettingsStore, useTerminalStore } from '@/application/stores'
 import { useHost, useSession, useAIAgent } from '@/application/hooks'
 import { hostRepository, sessionRepository } from '@/infrastructure/repositories'
-import { HostList, AddHostModal } from '@/presentation/components/sidebar'
+import { AddHostModal } from '@/presentation/components/sidebar'
 import { AIPanel } from '@/presentation/components/ai'
 import { Button, Icon, Modal } from '@/presentation/shared'
 import { APP_NAME } from '@/config'
@@ -24,10 +24,8 @@ const NAV_ITEMS = [
 export function AppLayout({ children }: AppLayoutProps) {
   const [isAddHostOpen, setIsAddHostOpen] = useState(false)
   const [activeNav, setActiveNav]         = useState<string | null>(null)
-  const [searchQuery, setSearchQuery]     = useState('')
 
   // Connection state
-  const [connectingHostId, setConnectingHostId] = useState<string | null>(null)
   const [connectError, setConnectError]         = useState<string | null>(null)
   const errorTimerRef                           = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -37,7 +35,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [showPendingPw, setShowPendingPw]       = useState(false)
 
   const { isAIPanelVisible, toggleAIPanel, openSettings } = useUIStore()
-  const { selectedHostId, hosts: allHosts } = useHostStore()
+  const { hosts: allHosts } = useHostStore()
   const { sessions, activeSessionId, setActiveSession } = useSessionStore()
   const { activeTerminalHandle } = useTerminalStore()
 
@@ -72,7 +70,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   const { messages, isStreaming, error, sendMessage, abort, clearMessages, executionMode, setExecutionMode } = useAIAgent(agentRunCommand, agentReadFile, activeHostForRules?.aiRules)
   const { loadApiKey, isApiKeyLoaded } = useSettingsStore()
-  const { hosts, saveHost, deleteHost, selectHost } = useHost(hostRepository)
+  const { hosts, saveHost } = useHost(hostRepository)
   const { connectHost, disconnectSession } = useSession(sessionRepository)
 
   const handleUpdateHostRules = useCallback(
@@ -96,7 +94,6 @@ export function AppLayout({ children }: AppLayoutProps) {
         setPendingPassword('')
         return
       }
-      setConnectingHostId(host.id)
       setConnectError(null)
       try {
         await connectHost(host)
@@ -106,8 +103,6 @@ export function AppLayout({ children }: AppLayoutProps) {
         setConnectError(`${msg}\n${debug}`)
         if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
         errorTimerRef.current = setTimeout(() => setConnectError(null), 10000)
-      } finally {
-        setConnectingHostId(null)
       }
     },
     [connectHost, sessions, setActiveSession],
@@ -133,17 +128,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     }
   }, [isApiKeyLoaded, loadApiKey])
 
-  const connectedHostIds = Array.from(sessions.values())
-    .filter((s) => s.status === 'connected')
-    .map((s) => s.hostId)
 
-  const filteredHosts = searchQuery.trim()
-    ? hosts.filter(
-        (h) =>
-          h.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          h.hostname.toLowerCase().includes(searchQuery.toLowerCase()),
-      )
-    : hosts
 
   /* ── SESSION MODE (any open sessions, including dashboard tab) ── */
   if (sessions.size > 0) {
@@ -416,73 +401,21 @@ export function AppLayout({ children }: AppLayoutProps) {
               {APP_NAME}
             </span>
           </div>
-          <div className="flex items-center gap-0.5">
-            <button className="p-1 rounded hover:bg-white/5 transition-colors" aria-label="Notifications">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" />
-              </svg>
-            </button>
-            <button
-              className="p-1 rounded hover:bg-white/5 transition-colors"
-              aria-label="Settings"
-              onClick={() => openSettings()}
-            >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
-            </button>
-            <div
-              className="w-6 h-6 rounded-full ml-0.5 flex items-center justify-center text-[0.5rem] font-bold"
-              style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11' }}
-            >
-              R
-            </div>
-          </div>
-        </div>
-
-        {/* Search bar */}
-        <div className="px-2 py-2" style={{ borderBottom: '1px solid #1d2126' }}>
-          <div className="flex items-center gap-2 px-2 py-1.5 rounded" style={{ background: '#1d2126' }}>
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#56687a" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+          <button
+            className="p-1 rounded hover:bg-white/5 transition-colors"
+            aria-label="Settings"
+            onClick={() => openSettings()}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
             </svg>
-            <input
-              type="text"
-              placeholder="Search connections…"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 bg-transparent outline-none text-[0.6875rem] text-text-secondary placeholder:text-text-muted"
-              style={{ fontFamily: "'Inter', sans-serif" }}
-            />
-            <span
-              className="text-[0.6rem] px-1 py-0.5 rounded font-mono"
-              style={{ border: '1px solid #3c494e', color: '#a8e8ff', letterSpacing: '0.02em', lineHeight: 1 }}
-            >
-              ⌘K
-            </span>
-          </div>
+          </button>
         </div>
 
-        {/* CONNECTIONS */}
+        {/* Nav items */}
         <div className="flex-1 overflow-y-auto">
-          <div className="px-3 pt-3 pb-1">
-            <span className="text-[0.6rem] font-semibold tracking-[0.15em] uppercase" style={{ color: '#56687a' }}>
-              Connections
-            </span>
-          </div>
-          <HostList
-            hosts={filteredHosts}
-            selectedHostId={selectedHostId}
-            connectedHostIds={connectedHostIds}
-            connectingHostId={connectingHostId}
-            onSelectHost={selectHost}
-            onConnectHost={handleConnect}
-            onDeleteHost={deleteHost}
-          />
-
-          {/* Nav items */}
-          <div className="px-2 pt-4 pb-2 flex flex-col gap-0.5">
+          <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
             {NAV_ITEMS.map((item) => (
               <button
                 key={item.id}

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -241,12 +241,6 @@ export function AppLayout({ children }: AppLayoutProps) {
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
               </svg>
             </button>
-            <div
-              className="w-7 h-7 rounded-full flex items-center justify-center text-[0.6rem] font-bold cursor-pointer"
-              style={{ background: 'linear-gradient(135deg, #a8e8ff44, #00d4ff44)', border: '1.5px solid #a8e8ff', color: '#a8e8ff' }}
-            >
-              R
-            </div>
           </div>
         </div>
 

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -130,8 +130,6 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   /* ── SESSION MODE (any open sessions, including dashboard tab) ── */
   if (sessions.size > 0) {
-    const activeSession = activeSessionId ? sessions.get(activeSessionId) : undefined
-    const activeHost    = activeSession ? hosts.find((h) => h.id === activeSession.hostId) : null
     const sessionHosts  = Array.from(sessions.values()).map((s) => ({
       session: s,
       host: hosts.find((h) => h.id === s.hostId),
@@ -254,87 +252,6 @@ export function AppLayout({ children }: AppLayoutProps) {
 
         {/* ── Body ───────────────────────────────────────────── */}
         <div className="flex flex-1 min-h-0">
-          {/* Active connections sidebar */}
-          <aside
-            className="w-[160px] shrink-0 flex flex-col"
-            style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
-          >
-            <div className="px-3 pt-3 pb-2">
-              <span
-                className="text-[0.6rem] font-semibold tracking-[0.15em] uppercase"
-                style={{ color: '#56687a' }}
-              >
-                Active Connections
-              </span>
-            </div>
-
-            <div className="flex-1 overflow-y-auto">
-              {sessionHosts.map(({ session, host }) => {
-                const isActive = session.id === activeSessionId
-                return (
-                  <div
-                    key={session.id}
-                    onClick={() => setActiveSession(session.id)}
-                    className="flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors"
-                    style={{
-                      borderLeft: isActive ? '3px solid #a8e8ff' : '3px solid transparent',
-                      background: isActive ? 'rgba(168,232,255,0.06)' : 'transparent',
-                    }}
-                  >
-                    <SessionTypeIcon hostId={session.hostId} />
-                    <span
-                      className="text-[0.6875rem] font-semibold truncate"
-                      style={{
-                        fontFamily: "'Inter', sans-serif",
-                        color: isActive ? '#a8e8ff' : '#8a9bb0',
-                        letterSpacing: '0.03em',
-                      }}
-                    >
-                      {host?.label?.toUpperCase() ?? session.hostId.toUpperCase()}
-                    </span>
-                  </div>
-                )
-              })}
-
-              {/* Demo mock connections when no real sessions */}
-              {sessionHosts.length === 0 && (
-                <MockConnections activeHost={activeHost?.label ?? 'PRODUCTION DB'} />
-              )}
-            </div>
-
-            {/* NEW HOST */}
-            <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
-              <button
-                onClick={() => setIsAddHostOpen(true)}
-                className="w-full py-2 text-[0.6rem] font-bold tracking-[0.1em] uppercase transition-opacity hover:opacity-90"
-                style={{
-                  background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)',
-                  color: '#0c0e11',
-                  borderRadius: '4px',
-                  fontFamily: "'Inter', sans-serif",
-                }}
-              >
-                New Host
-              </button>
-            </div>
-
-            {/* SUPPORT */}
-            <div
-              className="flex items-center gap-2 px-3 py-2"
-              style={{ borderTop: '1px solid #1d2126' }}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#56687a" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" /><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" /><line x1="12" y1="17" x2="12.01" y2="17" />
-              </svg>
-              <span
-                className="text-[0.6rem] tracking-widest uppercase"
-                style={{ color: '#56687a', fontFamily: "'Inter', sans-serif" }}
-              >
-                Support
-              </span>
-            </div>
-          </aside>
-
           {/* Main content */}
           <div className="flex-1 min-w-0 relative">{children}</div>
 
@@ -641,79 +558,4 @@ function NavIcon({ name, active }: { name: string; active: boolean }) {
   )
 }
 
-/** Icon for each connection type in the session sidebar */
-function SessionTypeIcon({ hostId }: { hostId: string }) {
-  const id = hostId.toLowerCase()
-  // DB connections
-  if (id.includes('db') || id.includes('data')) {
-    return (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <ellipse cx="12" cy="5" rx="9" ry="3" /><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" /><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
-      </svg>
-    )
-  }
-  // Web / server
-  if (id.includes('web') || id.includes('srv') || id.includes('server')) {
-    return (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="2" y="2" width="20" height="8" rx="2" ry="2" /><rect x="2" y="14" width="20" height="8" rx="2" ry="2" />
-        <line x1="6" y1="6" x2="6.01" y2="6" /><line x1="6" y1="18" x2="6.01" y2="18" />
-      </svg>
-    )
-  }
-  // Auth / keys
-  if (id.includes('auth') || id.includes('key')) {
-    return (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
-      </svg>
-    )
-  }
-  // Lock / vault
-  return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </svg>
-  )
-}
 
-/** Static mock connections shown in demo/empty state */
-function MockConnections({ activeHost }: { activeHost: string }) {
-  const mocks = [
-    { label: 'PRODUCTION DB',  icon: 'db'   },
-    { label: 'WEB-SRV-01',     icon: 'web'  },
-    { label: 'AUTH-NODES',     icon: 'auth' },
-    { label: 'VAULT-PRIMARY',  icon: 'lock' },
-  ]
-  return (
-    <>
-      {mocks.map((m) => {
-        const isActive = m.label === activeHost || activeHost.includes('PRODUCTION')
-          ? m.label === 'PRODUCTION DB'
-          : m.label === activeHost
-        return (
-          <div
-            key={m.label}
-            className="flex items-center gap-2 px-3 py-2 cursor-pointer"
-            style={{
-              borderLeft: isActive ? '3px solid #a8e8ff' : '3px solid transparent',
-              background: isActive ? 'rgba(168,232,255,0.06)' : 'transparent',
-            }}
-          >
-            <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: '#22c55e' }} />
-            <span
-              className="text-[0.6rem] font-semibold truncate"
-              style={{
-                fontFamily: "'Inter', sans-serif",
-                color: isActive ? '#a8e8ff' : '#8a9bb0',
-                letterSpacing: '0.06em',
-              }}
-            >
-              {m.label}
-            </span>
-          </div>
-        )
-      })}
-    </>
-  )
-}

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, CSSProperties } from 'react'
+import type { ReactNode } from 'react'
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { useHostStore, useSessionStore, useUIStore, useSettingsStore, useTerminalStore } from '@/application/stores'
@@ -6,7 +6,7 @@ import { useHost, useSession, useAIAgent } from '@/application/hooks'
 import { hostRepository, sessionRepository } from '@/infrastructure/repositories'
 import { AddHostModal } from '@/presentation/components/sidebar'
 import { AIPanel } from '@/presentation/components/ai'
-import { Button, Icon, Modal } from '@/presentation/shared'
+import { Button, Modal } from '@/presentation/shared'
 import { APP_NAME } from '@/config'
 import type { Host, AIRule } from '@/domain/entities'
 
@@ -15,13 +15,9 @@ interface AppLayoutProps {
 }
 
 /** Navigation items below CONNECTIONS (dashboard mode) */
-const NAV_ITEMS = [
-  { id: 'vault', label: 'VAULT', icon: 'lock' },
-] as const
 
 export function AppLayout({ children }: AppLayoutProps) {
   const [isAddHostOpen, setIsAddHostOpen] = useState(false)
-  const [activeNav, setActiveNav]         = useState<string | null>(null)
 
   // Connection state
   const [connectError, setConnectError]         = useState<string | null>(null)
@@ -32,7 +28,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [pendingPassword, setPendingPassword]   = useState('')
   const [showPendingPw, setShowPendingPw]       = useState(false)
 
-  const { isAIPanelVisible, toggleAIPanel, openSettings } = useUIStore()
+  const { openSettings } = useUIStore()
   const { hosts: allHosts } = useHostStore()
   const { sessions, activeSessionId, setActiveSession } = useSessionStore()
   const { activeTerminalHandle } = useTerminalStore()
@@ -281,139 +277,8 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   /* ── DASHBOARD MODE ──────────────────────────────────────────── */
   return (
-    <div className="flex h-screen w-screen overflow-hidden" style={{ background: '#0c0e11' }}>
-      {/* Sidebar */}
-      <aside
-        className="w-[200px] shrink-0 flex flex-col"
-        style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
-      >
-        {/* Top bar: branding + icons */}
-        <div
-          className="flex items-center justify-between px-3 py-2.5"
-          style={{ borderBottom: '1px solid #1d2126' }}
-        >
-          <div className="flex items-center gap-1.5">
-            <span
-              className="font-mono text-[0.65rem] font-bold px-1 py-0.5 rounded"
-              style={{
-                background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)',
-                color: '#0c0e11',
-                letterSpacing: '0.02em',
-              }}
-            >
-              &gt;_
-            </span>
-            <span
-              className="text-sm font-bold tracking-tight"
-              style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
-            >
-              {APP_NAME}
-            </span>
-          </div>
-          <button
-            className="p-1 rounded hover:bg-white/5 transition-colors"
-            aria-label="Settings"
-            onClick={() => openSettings()}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Nav items */}
-        <div className="flex-1 overflow-y-auto">
-          <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setActiveNav(item.id)}
-                className="flex items-center gap-2.5 px-2 py-1.5 rounded text-left w-full transition-colors"
-                style={{
-                  color: activeNav === item.id ? '#a8e8ff' : '#8a9bb0',
-                  background: activeNav === item.id ? 'rgba(168,232,255,0.08)' : 'transparent',
-                  fontFamily: "'Inter', sans-serif",
-                  fontSize: '0.6875rem',
-                  fontWeight: 500,
-                  letterSpacing: '0.08em',
-                }}
-              >
-                <NavIcon name={item.icon} active={activeNav === item.id} />
-                {item.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* + New Host */}
-        <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
-          <button
-            onClick={() => setIsAddHostOpen(true)}
-            className="w-full flex items-center justify-center gap-2 py-2 rounded font-semibold text-[0.6875rem] transition-opacity hover:opacity-90"
-            style={{
-              background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)',
-              color: '#0c0e11',
-              borderRadius: '4px',
-              letterSpacing: '0.05em',
-            }}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            New Host
-          </button>
-        </div>
-
-        {/* Status bar */}
-        <div
-          className="flex items-center gap-2 px-2 py-1.5 overflow-x-auto"
-          style={{ background: '#0c0e11', borderTop: '1px solid #1d2126', minHeight: 28 }}
-        >
-          <StatusChip><span style={{ color: '#22c55e' }}>●</span>&nbsp;OPTIMAL</StatusChip>
-          <StatusDivider />
-          <StatusChip>HOSTS: {hosts.length}</StatusChip>
-          <StatusDivider />
-          <StatusChip style={{ color: '#a8e8ff' }}>IDLE</StatusChip>
-        </div>
-      </aside>
-
-      {/* Main content */}
-      <div className="flex-1 min-w-0 flex flex-col" style={{ background: '#111317' }}>
-        <div
-          className="flex items-center justify-end px-3 py-1.5"
-          style={{ borderBottom: '1px solid #1d2126', background: '#111317' }}
-        >
-          <Button
-            variant={isAIPanelVisible ? 'primary' : 'ghost'}
-            size="sm"
-            onClick={toggleAIPanel}
-          >
-            <Icon name="ai" size={14} />
-            <span className="ml-1.5 text-[0.6875rem] font-semibold tracking-widest uppercase">AI</span>
-          </Button>
-        </div>
-        <div className="flex flex-1 min-h-0">
-          <div className="flex-1 min-w-0">{children}</div>
-          {isAIPanelVisible && (
-            <div className="w-[360px] shrink-0" style={{ borderLeft: '1px solid #1d2126' }}>
-              <AIPanel
-                messages={messages}
-                isStreaming={isStreaming}
-                error={error}
-                onSendMessage={sendMessage}
-                onAbort={abort}
-                onClearChat={clearMessages}
-                onRunCommand={onRunCommand}
-                executionMode={executionMode}
-                onSetExecutionMode={setExecutionMode}
-                hostRules={activeHostForRules?.aiRules ?? []}
-                onUpdateHostRules={handleUpdateHostRules}
-              />
-            </div>
-          )}
-        </div>
-      </div>
+    <div className="flex h-screen w-screen overflow-hidden" style={{ background: '#111317' }}>
+      <div className="flex-1 min-w-0">{children}</div>
 
       <AddHostModal
         isOpen={isAddHostOpen}
@@ -509,46 +374,6 @@ export function AppLayout({ children }: AppLayoutProps) {
       {/* Spin keyframe for loading spinner */}
       <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
     </div>
-  )
-}
-
-/* ── Tiny presentational helpers ───────────────────────────────── */
-
-function StatusDivider() {
-  return <span style={{ color: '#252a30', fontSize: '0.75rem' }}>|</span>
-}
-
-function StatusChip({ children, style }: { children: ReactNode; style?: CSSProperties }) {
-  return (
-    <span
-      className="whitespace-nowrap text-[0.55rem] font-mono font-semibold tracking-[0.12em] uppercase"
-      style={{ color: '#56687a', ...style }}
-    >
-      {children}
-    </span>
-  )
-}
-
-function NavIcon({ name, active }: { name: string; active: boolean }) {
-  const stroke = active ? '#a8e8ff' : '#56687a'
-  if (name === 'folder') {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-      </svg>
-    )
-  }
-  if (name === 'key') {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
-      </svg>
-    )
-  }
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </svg>
   )
 }
 

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -281,96 +281,136 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   /* ── DASHBOARD MODE ──────────────────────────────────────────── */
   return (
-    <div className="flex h-screen w-screen overflow-hidden" style={{ background: '#0c0e11' }}>
-      {/* Sidebar */}
-      <aside
-        className="w-[200px] shrink-0 flex flex-col"
-        style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
+    <div className="flex flex-col h-screen w-screen overflow-hidden" style={{ background: '#0c0e11' }}>
+      {/* ── Global top bar (same as session mode) ──────────────── */}
+      <div
+        className="flex items-center h-[44px] shrink-0 gap-3 px-4"
+        style={{ background: '#111317', borderBottom: '1px solid #1d2126' }}
       >
-        {/* Branding + settings */}
+        {/* Logo */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span
+            className="font-mono text-[0.6rem] font-bold px-1 py-0.5 rounded"
+            style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11' }}
+          >
+            &gt;_
+          </span>
+          <span
+            className="text-sm font-bold tracking-tight"
+            style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
+          >
+            {APP_NAME}
+          </span>
+        </div>
+
+        {/* Jump to command */}
         <div
-          className="flex items-center justify-between px-3 py-2.5"
-          style={{ borderBottom: '1px solid #1d2126' }}
+          className="flex-1 max-w-xs flex items-center gap-2 px-3 py-1.5 rounded"
+          style={{ background: '#161a1e', border: '1px solid #1d2126' }}
         >
-          <div className="flex items-center gap-1.5">
-            <span
-              className="font-mono text-[0.65rem] font-bold px-1 py-0.5 rounded"
-              style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', letterSpacing: '0.02em' }}
-            >
-              &gt;_
-            </span>
-            <span
-              className="text-sm font-bold tracking-tight"
-              style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
-            >
-              {APP_NAME}
-            </span>
-          </div>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#56687a" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <span className="text-[0.6875rem]" style={{ fontFamily: "'Inter', sans-serif", color: '#56687a' }}>
+            Jump to command…
+          </span>
+        </div>
+
+        {/* Dashboard tab (always active here) */}
+        <div className="flex items-center flex-1 overflow-x-auto" style={{ marginLeft: '12px' }}>
           <button
-            className="p-1 rounded hover:bg-white/5 transition-colors"
+            className="flex items-center gap-1.5 px-3 h-[44px] text-[0.6875rem] font-medium shrink-0"
+            style={{
+              color: '#a8e8ff',
+              borderBottom: '2px solid #a8e8ff',
+              fontFamily: "'Inter', sans-serif",
+              letterSpacing: '0.04em',
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              <polyline points="9 22 9 12 15 12 15 22" />
+            </svg>
+            Dashboard
+          </button>
+        </div>
+
+        {/* Settings */}
+        <div className="flex items-center gap-1.5 shrink-0" style={{ marginLeft: '16px' }}>
+          <button
+            className="p-1.5 rounded hover:bg-white/5 transition-colors"
             aria-label="Settings"
             onClick={() => openSettings()}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="3" />
               <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
             </svg>
           </button>
         </div>
+      </div>
 
-        {/* Nav items */}
-        <div className="flex-1 overflow-y-auto">
-          <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => setActiveNav(item.id)}
-                className="flex items-center gap-2.5 px-2 py-1.5 rounded text-left w-full transition-colors"
-                style={{
-                  color: activeNav === item.id ? '#a8e8ff' : '#8a9bb0',
-                  background: activeNav === item.id ? 'rgba(168,232,255,0.08)' : 'transparent',
-                  fontFamily: "'Inter', sans-serif",
-                  fontSize: '0.6875rem',
-                  fontWeight: 500,
-                  letterSpacing: '0.08em',
-                }}
-              >
-                <NavIcon name={item.icon} active={activeNav === item.id} />
-                {item.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* + New Host */}
-        <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
-          <button
-            onClick={() => setIsAddHostOpen(true)}
-            className="w-full flex items-center justify-center gap-2 py-2 rounded font-semibold text-[0.6875rem] transition-opacity hover:opacity-90"
-            style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', borderRadius: '4px', letterSpacing: '0.05em' }}
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            New Host
-          </button>
-        </div>
-
-        {/* Status bar */}
-        <div
-          className="flex items-center gap-2 px-2 py-1.5 overflow-x-auto"
-          style={{ background: '#0c0e11', borderTop: '1px solid #1d2126', minHeight: 28 }}
+      {/* ── Body ───────────────────────────────────────────────── */}
+      <div className="flex flex-1 min-h-0">
+        {/* Sidebar */}
+        <aside
+          className="w-[200px] shrink-0 flex flex-col"
+          style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
         >
-          <StatusChip><span style={{ color: '#22c55e' }}>●</span>&nbsp;OPTIMAL</StatusChip>
-          <StatusDivider />
-          <StatusChip>HOSTS: {hosts.length}</StatusChip>
-          <StatusDivider />
-          <StatusChip style={{ color: '#a8e8ff' }}>IDLE</StatusChip>
-        </div>
-      </aside>
+          {/* Nav items */}
+          <div className="flex-1 overflow-y-auto">
+            <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
+              {NAV_ITEMS.map((item) => (
+                <button
+                  key={item.id}
+                  onClick={() => setActiveNav(item.id)}
+                  className="flex items-center gap-2.5 px-2 py-1.5 rounded text-left w-full transition-colors"
+                  style={{
+                    color: activeNav === item.id ? '#a8e8ff' : '#8a9bb0',
+                    background: activeNav === item.id ? 'rgba(168,232,255,0.08)' : 'transparent',
+                    fontFamily: "'Inter', sans-serif",
+                    fontSize: '0.6875rem',
+                    fontWeight: 500,
+                    letterSpacing: '0.08em',
+                  }}
+                >
+                  <NavIcon name={item.icon} active={activeNav === item.id} />
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
 
-      {/* Main content */}
-      <div className="flex-1 min-w-0" style={{ background: '#111317' }}>{children}</div>
+          {/* + New Host */}
+          <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
+            <button
+              onClick={() => setIsAddHostOpen(true)}
+              className="w-full flex items-center justify-center gap-2 py-2 rounded font-semibold text-[0.6875rem] transition-opacity hover:opacity-90"
+              style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', borderRadius: '4px', letterSpacing: '0.05em' }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              New Host
+            </button>
+          </div>
+
+          {/* Status bar */}
+          <div
+            className="flex items-center gap-2 px-2 py-1.5 overflow-x-auto"
+            style={{ background: '#0c0e11', borderTop: '1px solid #1d2126', minHeight: 28 }}
+          >
+            <StatusChip><span style={{ color: '#22c55e' }}>●</span>&nbsp;OPTIMAL</StatusChip>
+            <StatusDivider />
+            <StatusChip>HOSTS: {hosts.length}</StatusChip>
+            <StatusDivider />
+            <StatusChip style={{ color: '#a8e8ff' }}>IDLE</StatusChip>
+          </div>
+        </aside>
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0" style={{ background: '#111317' }}>{children}</div>
+      </div>
 
       <AddHostModal
         isOpen={isAddHostOpen}

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -246,28 +246,84 @@ export function AppLayout({ children }: AppLayoutProps) {
 
         {/* ── Body ───────────────────────────────────────────── */}
         <div className="flex flex-1 min-h-0">
-          {/* Main content */}
-          <div className="flex-1 min-w-0 relative">{children}</div>
-
-          {/* AI Panel — always visible in session mode */}
-          <div
-            className="w-[280px] shrink-0 flex flex-col"
-            style={{ borderLeft: '1px solid #1d2126' }}
-          >
-            <AIPanel
-              messages={messages}
-              isStreaming={isStreaming}
-              error={error}
-              onSendMessage={sendMessage}
-              onAbort={abort}
-              onClearChat={clearMessages}
-              onRunCommand={onRunCommand}
-              executionMode={executionMode}
-              onSetExecutionMode={setExecutionMode}
-              hostRules={activeHostForRules?.aiRules ?? []}
-              onUpdateHostRules={handleUpdateHostRules}
-            />
-          </div>
+          {activeSessionId === null ? (
+            /* Dashboard view inside session mode: sidebar + content, no AI panel */
+            <>
+              <aside
+                className="w-[200px] shrink-0 flex flex-col"
+                style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
+              >
+                <div className="flex-1 overflow-y-auto">
+                  <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
+                    {NAV_ITEMS.map((item) => (
+                      <button
+                        key={item.id}
+                        onClick={() => setActiveNav(item.id)}
+                        className="flex items-center gap-2.5 px-2 py-1.5 rounded text-left w-full transition-colors"
+                        style={{
+                          color: activeNav === item.id ? '#a8e8ff' : '#8a9bb0',
+                          background: activeNav === item.id ? 'rgba(168,232,255,0.08)' : 'transparent',
+                          fontFamily: "'Inter', sans-serif",
+                          fontSize: '0.6875rem',
+                          fontWeight: 500,
+                          letterSpacing: '0.08em',
+                        }}
+                      >
+                        <NavIcon name={item.icon} active={activeNav === item.id} />
+                        {item.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
+                  <button
+                    onClick={() => setIsAddHostOpen(true)}
+                    className="w-full flex items-center justify-center gap-2 py-2 rounded font-semibold text-[0.6875rem] transition-opacity hover:opacity-90"
+                    style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', borderRadius: '4px', letterSpacing: '0.05em' }}
+                  >
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                      <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                    New Host
+                  </button>
+                </div>
+                <div
+                  className="flex items-center gap-2 px-2 py-1.5 overflow-x-auto"
+                  style={{ background: '#0c0e11', borderTop: '1px solid #1d2126', minHeight: 28 }}
+                >
+                  <StatusChip><span style={{ color: '#22c55e' }}>●</span>&nbsp;OPTIMAL</StatusChip>
+                  <StatusDivider />
+                  <StatusChip>HOSTS: {hosts.length}</StatusChip>
+                  <StatusDivider />
+                  <StatusChip style={{ color: '#a8e8ff' }}>IDLE</StatusChip>
+                </div>
+              </aside>
+              <div className="flex-1 min-w-0" style={{ background: '#111317' }}>{children}</div>
+            </>
+          ) : (
+            /* Active session view: content + AI panel, no sidebar */
+            <>
+              <div className="flex-1 min-w-0 relative">{children}</div>
+              <div
+                className="w-[280px] shrink-0 flex flex-col"
+                style={{ borderLeft: '1px solid #1d2126' }}
+              >
+                <AIPanel
+                  messages={messages}
+                  isStreaming={isStreaming}
+                  error={error}
+                  onSendMessage={sendMessage}
+                  onAbort={abort}
+                  onClearChat={clearMessages}
+                  onRunCommand={onRunCommand}
+                  executionMode={executionMode}
+                  onSetExecutionMode={setExecutionMode}
+                  hostRules={activeHostForRules?.aiRules ?? []}
+                  onUpdateHostRules={handleUpdateHostRules}
+                />
+              </div>
+            </>
+          )}
         </div>
 
         <AddHostModal

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -16,9 +16,7 @@ interface AppLayoutProps {
 
 /** Navigation items below CONNECTIONS (dashboard mode) */
 const NAV_ITEMS = [
-  { id: 'history', label: 'HISTORY', icon: 'folder' },
-  { id: 'keys',    label: 'KEYS',    icon: 'key'    },
-  { id: 'vault',   label: 'VAULT',   icon: 'lock'   },
+  { id: 'vault', label: 'VAULT', icon: 'lock' },
 ] as const
 
 export function AppLayout({ children }: AppLayoutProps) {

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, CSSProperties } from 'react'
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { useHostStore, useSessionStore, useUIStore, useSettingsStore, useTerminalStore } from '@/application/stores'
@@ -14,10 +14,14 @@ interface AppLayoutProps {
   children: ReactNode
 }
 
-/** Navigation items below CONNECTIONS (dashboard mode) */
+/** Navigation items (dashboard mode) */
+const NAV_ITEMS = [
+  { id: 'vault', label: 'VAULT', icon: 'lock' },
+] as const
 
 export function AppLayout({ children }: AppLayoutProps) {
   const [isAddHostOpen, setIsAddHostOpen] = useState(false)
+  const [activeNav, setActiveNav]         = useState<string | null>(null)
 
   // Connection state
   const [connectError, setConnectError]         = useState<string | null>(null)
@@ -277,8 +281,96 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   /* ── DASHBOARD MODE ──────────────────────────────────────────── */
   return (
-    <div className="flex h-screen w-screen overflow-hidden" style={{ background: '#111317' }}>
-      <div className="flex-1 min-w-0">{children}</div>
+    <div className="flex h-screen w-screen overflow-hidden" style={{ background: '#0c0e11' }}>
+      {/* Sidebar */}
+      <aside
+        className="w-[200px] shrink-0 flex flex-col"
+        style={{ background: '#111317', borderRight: '1px solid #1d2126' }}
+      >
+        {/* Branding + settings */}
+        <div
+          className="flex items-center justify-between px-3 py-2.5"
+          style={{ borderBottom: '1px solid #1d2126' }}
+        >
+          <div className="flex items-center gap-1.5">
+            <span
+              className="font-mono text-[0.65rem] font-bold px-1 py-0.5 rounded"
+              style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', letterSpacing: '0.02em' }}
+            >
+              &gt;_
+            </span>
+            <span
+              className="text-sm font-bold tracking-tight"
+              style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
+            >
+              {APP_NAME}
+            </span>
+          </div>
+          <button
+            className="p-1 rounded hover:bg-white/5 transition-colors"
+            aria-label="Settings"
+            onClick={() => openSettings()}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Nav items */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="px-2 pt-3 pb-2 flex flex-col gap-0.5">
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => setActiveNav(item.id)}
+                className="flex items-center gap-2.5 px-2 py-1.5 rounded text-left w-full transition-colors"
+                style={{
+                  color: activeNav === item.id ? '#a8e8ff' : '#8a9bb0',
+                  background: activeNav === item.id ? 'rgba(168,232,255,0.08)' : 'transparent',
+                  fontFamily: "'Inter', sans-serif",
+                  fontSize: '0.6875rem',
+                  fontWeight: 500,
+                  letterSpacing: '0.08em',
+                }}
+              >
+                <NavIcon name={item.icon} active={activeNav === item.id} />
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* + New Host */}
+        <div className="px-2 py-2" style={{ borderTop: '1px solid #1d2126' }}>
+          <button
+            onClick={() => setIsAddHostOpen(true)}
+            className="w-full flex items-center justify-center gap-2 py-2 rounded font-semibold text-[0.6875rem] transition-opacity hover:opacity-90"
+            style={{ background: 'linear-gradient(135deg, #a8e8ff, #00d4ff)', color: '#0c0e11', borderRadius: '4px', letterSpacing: '0.05em' }}
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            New Host
+          </button>
+        </div>
+
+        {/* Status bar */}
+        <div
+          className="flex items-center gap-2 px-2 py-1.5 overflow-x-auto"
+          style={{ background: '#0c0e11', borderTop: '1px solid #1d2126', minHeight: 28 }}
+        >
+          <StatusChip><span style={{ color: '#22c55e' }}>●</span>&nbsp;OPTIMAL</StatusChip>
+          <StatusDivider />
+          <StatusChip>HOSTS: {hosts.length}</StatusChip>
+          <StatusDivider />
+          <StatusChip style={{ color: '#a8e8ff' }}>IDLE</StatusChip>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0" style={{ background: '#111317' }}>{children}</div>
 
       <AddHostModal
         isOpen={isAddHostOpen}
@@ -374,6 +466,47 @@ export function AppLayout({ children }: AppLayoutProps) {
       {/* Spin keyframe for loading spinner */}
       <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
     </div>
+  )
+}
+
+/* ── Tiny presentational helpers ───────────────────────────────── */
+
+function StatusDivider() {
+  return <span style={{ color: '#252a30', fontSize: '0.75rem' }}>|</span>
+}
+
+function StatusChip({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  return (
+    <span
+      className="whitespace-nowrap text-[0.55rem] font-mono font-semibold tracking-[0.12em] uppercase"
+      style={{ color: '#56687a', ...style }}
+    >
+      {children}
+    </span>
+  )
+}
+
+function NavIcon({ name, active }: { name: string; active: boolean }) {
+  const stroke = active ? '#a8e8ff' : '#56687a'
+  if (name === 'folder') {
+    return (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+      </svg>
+    )
+  }
+  if (name === 'key') {
+    return (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
+      </svg>
+    )
+  }
+  // lock / vault (default)
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
   )
 }
 

--- a/src/presentation/pages/Dashboard.tsx
+++ b/src/presentation/pages/Dashboard.tsx
@@ -2,49 +2,23 @@ import { useCallback, useEffect, useState } from 'react'
 import { useHost, useSession } from '@/application/hooks'
 import { useSessionStore } from '@/application/stores'
 import { hostRepository, sessionRepository } from '@/infrastructure/repositories'
-import type { ReactNode } from 'react'
 import type { Host } from '@/domain/entities'
 
-/* ── Static mock data for Vault & Credentials ────────────────── */
-const VAULT_GROUPS = [
-  {
-    id: 'project-alpha',
-    label: 'PROJECT ALPHA',
-    defaultOpen: true,
-    credentials: [
-      { id: 'c1', name: 'id_rsa_alpha',    type: 'key',  tag: 'ED25519',   tagColor: '#a8e8ff' },
-      { id: 'c2', name: 'sudo-vault-pass', type: 'pass', tag: 'ENCRYPTED', tagColor: '#f59e0b' },
-    ],
-  },
-  {
-    id: 'security-audit',
-    label: 'SECURITY AUDIT',
-    defaultOpen: false,
-    credentials: [],
-  },
-]
-
-/* ── Recent sessions mock (shown when no real sessions exist) ─── */
-const RECENT_MOCK = [
-  { id: 'm1', name: 'Worker Node 4',  address: 'root@192.168.1.45',     icon: 'terminal', ago: '2M AGO'    },
-  { id: 'm2', name: 'Auth Service',   address: 'ubuntu@aws-us-east-1',  icon: 'list',     ago: '1H AGO'    },
-  { id: 'm3', name: 'Legacy Gateway', address: 'admin@172.16.0.2',      icon: 'cloud',    ago: 'YESTERDAY' },
-]
-
 export function Dashboard() {
-  const { hosts, loadHosts }    = useHost(hostRepository)
-  const { sessions }             = useSessionStore()
-  const { connectHost }          = useSession(sessionRepository)
-  const [quickConnect, setQuickConnect] = useState('')
-  const [connecting, setConnecting]     = useState(false)
+  const { hosts, loadHosts }                    = useHost(hostRepository)
+  const { sessions }                             = useSessionStore()
+  const { connectHost }                          = useSession(sessionRepository)
+  const [quickConnect, setQuickConnect]          = useState('')
+  const [quickConnecting, setQuickConnecting]    = useState(false)
+  const [connectingId, setConnectingId]          = useState<string | null>(null)
 
   useEffect(() => { loadHosts() }, [loadHosts])
 
+  /* ── Quick Connect ─────────────────────────────────────────── */
   const handleQuickConnect = useCallback(async () => {
     const raw = quickConnect.trim()
     if (!raw) return
 
-    // Parse  user@hostname:port
     let username = ''
     let hostname = raw
     let port     = 22
@@ -60,7 +34,6 @@ export function Dashboard() {
       port     = parseInt(p, 10) || 22
     }
 
-    // Prefer an existing saved host; otherwise create an ad-hoc one
     const existing = hosts.find(
       (h) => h.hostname === hostname && (!username || h.username === username)
     )
@@ -76,34 +49,41 @@ export function Dashboard() {
     }
 
     try {
-      setConnecting(true)
+      setQuickConnecting(true)
       await connectHost(host)
     } catch (err) {
       console.error('[Dashboard] quick-connect failed:', err)
     } finally {
-      setConnecting(false)
+      setQuickConnecting(false)
     }
   }, [quickConnect, hosts, connectHost])
 
-  /* Last 3 real sessions (newest first), or fall back to mock */
-  const recentSessions = (() => {
-    const live = Array.from(sessions.values()).slice(-3).reverse()
-    if (live.length > 0) return null // render real sessions (handled below)
-    return RECENT_MOCK
-  })()
+  /* ── Per-card connect ──────────────────────────────────────── */
+  const handleConnectHost = useCallback(async (host: Host) => {
+    try {
+      setConnectingId(host.id)
+      await connectHost(host)
+    } catch (err) {
+      console.error('[Dashboard] connect failed:', err)
+    } finally {
+      setConnectingId(null)
+    }
+  }, [connectHost])
+
+  /* Active session ids for status badges */
+  const connectedHostIds = new Set(Array.from(sessions.values()).map((s) => s.hostId))
 
   return (
     <div
       className="flex flex-col h-full overflow-y-auto"
       style={{ background: '#111317', padding: '0 24px 24px' }}
     >
-      {/* ── Quick Connect bar ────────────────────────────────────── */}
-      <div className="pt-5 pb-4">
+      {/* ── Quick Connect bar ──────────────────────────────────── */}
+      <div className="pt-5 pb-5">
         <div
           className="flex items-center gap-3 px-4 py-2.5 rounded"
           style={{ background: '#161a1e', border: '1px solid #1d2126' }}
         >
-          {/* ssh label */}
           <div className="flex items-center gap-2 shrink-0">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a9bb0" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
               <rect x="2" y="3" width="20" height="14" rx="2" /><line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
@@ -115,9 +95,7 @@ export function Dashboard() {
               ssh
             </span>
           </div>
-          {/* Divider */}
           <span style={{ color: '#252a30', fontSize: '1rem' }}>|</span>
-          {/* Input */}
           <input
             type="text"
             placeholder="user@hostname:port"
@@ -127,9 +105,8 @@ export function Dashboard() {
             className="flex-1 bg-transparent outline-none text-text-primary placeholder:text-text-muted"
             style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.6875rem' }}
           />
-          {/* Connect button */}
           <button
-            disabled={connecting || !quickConnect.trim()}
+            disabled={quickConnecting || !quickConnect.trim()}
             onClick={handleQuickConnect}
             className="shrink-0 px-4 py-1.5 font-semibold tracking-widest transition-opacity hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
             style={{
@@ -141,193 +118,41 @@ export function Dashboard() {
               letterSpacing: '0.08em',
             }}
           >
-            {connecting ? 'CONNECTING…' : 'CONNECT'}
+            {quickConnecting ? 'CONNECTING…' : 'CONNECT'}
           </button>
         </div>
       </div>
 
-      {/* ── Recent Sessions ──────────────────────────────────────── */}
-      <section className="mb-6">
-        <div className="flex items-center gap-3 mb-3">
-          <h2
-            className="text-sm font-semibold"
-            style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
-          >
-            Recent Sessions
-          </h2>
-          {/* Decorative line */}
-          <div className="flex-1 h-px" style={{ background: '#1d2126' }} />
-        </div>
-
-        <div className="grid grid-cols-3 gap-3">
-          {recentSessions
-            ? /* Mock cards */
-              recentSessions.map((s) => (
-                <SessionCard key={s.id} icon={s.icon} name={s.name} address={s.address} ago={s.ago} />
-              ))
-            : /* Live cards */
-              Array.from(sessions.values())
-                .slice(-3)
-                .reverse()
-                .map((session) => {
-                  const host = hosts.find((h) => h.id === session.hostId)
-                  return (
-                    <SessionCard
-                      key={session.id}
-                      icon="terminal"
-                      name={host?.label ?? session.hostId}
-                      address={host ? `${host.username}@${host.hostname}` : '—'}
-                      ago="recent"
-                    />
-                  )
-                })}
-        </div>
-      </section>
-
-      {/* ── Vault & Credentials ─────────────────────────────────── */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2
-            className="text-sm font-semibold"
-            style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
-          >
-            Vault &amp; Credentials
-          </h2>
-          <span
-            className="text-[0.6rem] font-mono tracking-widest"
-            style={{ color: '#56687a' }}
-          >
-            8 Total Identities
-          </span>
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          {VAULT_GROUPS.map((group) => (
-            <VaultGroup key={group.id} group={group} />
-          ))}
-        </div>
-      </section>
-    </div>
-  )
-}
-
-/* ── SessionCard ──────────────────────────────────────────────── */
-function SessionCard({
-  icon,
-  name,
-  address,
-  ago,
-}: {
-  icon: string
-  name: string
-  address: string
-  ago: string
-}) {
-  return (
-    <div
-      className="flex flex-col gap-2 p-3 rounded cursor-pointer hover:border-accent-primary/30 transition-colors"
-      style={{ background: '#161a1e', border: '1px solid rgba(60,73,78,0.2)' }}
-    >
-      {/* Top row: icon + timestamp */}
-      <div className="flex items-start justify-between">
-        <SessionIcon name={icon} />
-        <span
-          className="text-[0.55rem] font-mono tracking-widest"
-          style={{ color: '#56687a' }}
-        >
-          {ago}
-        </span>
-      </div>
-      {/* Name */}
-      <div>
-        <span
-          className="text-sm font-semibold block"
+      {/* ── Section header ─────────────────────────────────────── */}
+      <div className="flex items-center gap-3 mb-4">
+        <h2
+          className="text-sm font-semibold shrink-0"
           style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
         >
-          {name}
-        </span>
+          Saved Connections
+        </h2>
+        <div className="flex-1 h-px" style={{ background: '#1d2126' }} />
         <span
-          className="text-[0.625rem] block mt-0.5 truncate"
-          style={{ fontFamily: "'JetBrains Mono', monospace", color: '#8a9bb0' }}
+          className="text-[0.6rem] font-mono tracking-widest shrink-0"
+          style={{ color: '#56687a' }}
         >
-          {address}
+          {hosts.length} HOST{hosts.length !== 1 ? 'S' : ''}
         </span>
       </div>
-    </div>
-  )
-}
 
-/* ── SessionIcon ─────────────────────────────────────────────── */
-function SessionIcon({ name }: { name: string }) {
-  const s = { stroke: '#a8e8ff', strokeWidth: '1.8', strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const, fill: 'none' }
-  if (name === 'terminal') {
-    return (
-      <svg width="16" height="16" viewBox="0 0 24 24" {...s}>
-        <rect x="2" y="3" width="20" height="14" rx="2" /><polyline points="8 21 12 17 16 21" />
-      </svg>
-    )
-  }
-  if (name === 'list') {
-    return (
-      <svg width="16" height="16" viewBox="0 0 24 24" {...s}>
-        <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
-        <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
-      </svg>
-    )
-  }
-  /* cloud */
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" {...s}>
-      <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
-    </svg>
-  )
-}
-
-/* ── VaultGroup ──────────────────────────────────────────────── */
-function VaultGroup({
-  group,
-}: {
-  group: (typeof VAULT_GROUPS)[number]
-}) {
-  const [open, setOpen] = useState(group.defaultOpen)
-
-  return (
-    <div
-      className="rounded overflow-hidden"
-      style={{ background: '#161a1e', border: '1px solid rgba(60,73,78,0.2)' }}
-    >
-      {/* Header */}
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-white/[0.03] transition-colors"
-      >
-        <div className="flex items-center gap-2">
-          {/* Folder icon */}
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-          </svg>
-          <span
-            className="text-[0.6rem] font-semibold tracking-[0.15em] uppercase"
-            style={{ fontFamily: "'Inter', sans-serif", color: '#a8e8ff' }}
-          >
-            {group.label}
-          </span>
-        </div>
-        {/* Chevron */}
-        <svg
-          width="12" height="12" viewBox="0 0 24 24" fill="none"
-          stroke="#56687a" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-          style={{ transform: open ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms ease-out' }}
-        >
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </button>
-
-      {/* Credentials */}
-      {open && group.credentials.length > 0 && (
-        <div style={{ borderTop: '1px solid #1d2126' }}>
-          {group.credentials.map((cred) => (
-            <CredentialRow key={cred.id} name={cred.name} type={cred.type} tag={cred.tag} tagColor={cred.tagColor} />
+      {/* ── Host grid ──────────────────────────────────────────── */}
+      {hosts.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))' }}>
+          {hosts.map((host) => (
+            <HostCard
+              key={host.id}
+              host={host}
+              isConnected={connectedHostIds.has(host.id)}
+              isConnecting={connectingId === host.id}
+              onConnect={handleConnectHost}
+            />
           ))}
         </div>
       )}
@@ -335,55 +160,167 @@ function VaultGroup({
   )
 }
 
-/* ── CredentialRow ───────────────────────────────────────────── */
-function CredentialRow({
-  name,
-  type,
-  tag,
-  tagColor,
+/* ── HostCard ─────────────────────────────────────────────────── */
+function HostCard({
+  host,
+  isConnected,
+  isConnecting,
+  onConnect,
 }: {
-  name: string
-  type: string
-  tag: string
-  tagColor: string
+  host: Host
+  isConnected: boolean
+  isConnecting: boolean
+  onConnect: (host: Host) => void
 }) {
   return (
     <div
-      className="flex items-center justify-between px-3 py-2 hover:bg-white/[0.03] transition-colors cursor-pointer"
-      style={{ borderBottom: '1px solid #1a1f24' }}
+      className="flex flex-col gap-3 p-4 rounded-lg transition-all duration-150 group"
+      style={{
+        background: '#161a1e',
+        border: `1px solid ${isConnected ? 'rgba(0,212,255,0.25)' : 'rgba(60,73,78,0.25)'}`,
+        boxShadow: isConnected ? '0 0 0 1px rgba(0,212,255,0.08) inset' : 'none',
+      }}
     >
-      <div className="flex items-center gap-2">
-        <CredIcon type={type} />
-        <span
-          className="text-[0.6875rem]"
-          style={{ fontFamily: "'JetBrains Mono', monospace", color: '#e2e2e6' }}
+      {/* Top row: icon + status */}
+      <div className="flex items-start justify-between">
+        <div
+          className="flex items-center justify-center rounded"
+          style={{ width: 32, height: 32, background: 'rgba(168,232,255,0.07)' }}
         >
-          {name}
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a8e8ff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2" /><polyline points="8 21 12 17 16 21" />
+          </svg>
+        </div>
+
+        {isConnected ? (
+          <span
+            className="text-[0.55rem] font-mono font-semibold tracking-widest px-1.5 py-0.5 rounded-sm"
+            style={{ background: 'rgba(74,222,128,0.12)', color: '#4ade80' }}
+          >
+            CONNECTED
+          </span>
+        ) : (
+          <AuthBadge method={host.authMethod} />
+        )}
+      </div>
+
+      {/* Host info */}
+      <div className="flex-1 min-w-0">
+        <span
+          className="text-sm font-semibold block truncate"
+          style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#e2e2e6' }}
+        >
+          {host.label}
+        </span>
+        <span
+          className="text-[0.625rem] block mt-0.5 truncate"
+          style={{ fontFamily: "'JetBrains Mono', monospace", color: '#8a9bb0' }}
+        >
+          {host.username}@{host.hostname}:{host.port}
         </span>
       </div>
-      <span
-        className="text-[0.55rem] font-mono font-semibold px-1.5 py-0.5 rounded-sm tracking-widest"
-        style={{ background: `${tagColor}22`, color: tagColor }}
+
+      {/* Tags */}
+      {host.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {host.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-[0.55rem] font-mono tracking-wider px-1.5 py-0.5 rounded-sm"
+              style={{ background: 'rgba(138,155,176,0.1)', color: '#8a9bb0' }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Connect button */}
+      <button
+        disabled={isConnecting}
+        onClick={() => onConnect(host)}
+        className="w-full flex items-center justify-center gap-2 py-1.5 rounded font-semibold tracking-widest transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+        style={{
+          background: isConnected
+            ? 'rgba(74,222,128,0.08)'
+            : 'rgba(168,232,255,0.06)',
+          border: `1px solid ${isConnected ? 'rgba(74,222,128,0.2)' : 'rgba(168,232,255,0.12)'}`,
+          color: isConnected ? '#4ade80' : '#a8e8ff',
+          fontSize: '0.6rem',
+          fontFamily: "'Inter', sans-serif",
+          letterSpacing: '0.12em',
+        }}
       >
-        {tag}
-      </span>
+        {isConnecting ? (
+          <>
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" style={{ animation: 'spin 1s linear infinite' }}>
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+            CONNECTING…
+          </>
+        ) : isConnected ? (
+          <>
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 3 21 3 21 9" /><path d="M10 14L21 3" /><path d="M21 16v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
+            </svg>
+            OPEN SESSION
+          </>
+        ) : (
+          <>
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M5 12h14" /><polyline points="12 5 19 12 12 19" />
+            </svg>
+            CONNECT
+          </>
+        )}
+      </button>
     </div>
   )
 }
 
-function CredIcon({ type }: { type: string }): ReactNode {
-  const color = '#56687a'
-  if (type === 'key') {
-    return (
-      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
-      </svg>
-    )
-  }
-  /* password / dots */
+/* ── AuthBadge ────────────────────────────────────────────────── */
+function AuthBadge({ method }: { method: Host['authMethod'] }) {
+  const isKey = method === 'privateKey'
   return (
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
-    </svg>
+    <span
+      className="flex items-center gap-1 text-[0.55rem] font-mono font-semibold tracking-widest px-1.5 py-0.5 rounded-sm"
+      style={{
+        background: isKey ? 'rgba(168,232,255,0.08)' : 'rgba(245,158,11,0.08)',
+        color: isKey ? '#a8e8ff' : '#f59e0b',
+      }}
+    >
+      {isKey ? (
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
+        </svg>
+      ) : (
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      )}
+      {isKey ? 'KEY' : 'PASS'}
+    </span>
+  )
+}
+
+/* ── EmptyState ───────────────────────────────────────────────── */
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 gap-3 py-20">
+      <div
+        className="flex items-center justify-center rounded-full"
+        style={{ width: 48, height: 48, background: 'rgba(168,232,255,0.05)', border: '1px solid rgba(168,232,255,0.1)' }}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#56687a" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="3" width="20" height="14" rx="2" /><polyline points="8 21 12 17 16 21" />
+        </svg>
+      </div>
+      <p
+        className="text-xs text-center"
+        style={{ fontFamily: "'Space Grotesk', sans-serif", color: '#56687a' }}
+      >
+        No saved connections yet.<br />Add a host using the sidebar or quick-connect above.
+      </p>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

A series of incremental UI redesign changes to clean up the dashboard and session layouts.

## Changes

- **Dashboard** — Replaced mock-data panels with a responsive host grid (`HostCard`, `AuthBadge`, `EmptyState`); hosts load from real store
- **Sidebar cleanup** — Removed HostList, Connections section header, notifications bell, and user avatar ("R") from the dashboard sidebar
- **Nav items** — Trimmed to only `VAULT` (removed HISTORY and KEYS)
- **Session mode** — Removed the Active Connections sidebar when connected to a host
- **Session topbar** — Removed user avatar ("R") from topbar in session mode
- **AI panel** — Hidden on Dashboard tab; only shown when an active session tab is selected
- **Layout consistency** — Both dashboard mode and session mode now use the same `flex-col` structure with a matching 44px full-width topbar
- **Dashboard tab navigation fix** — When navigating back to the Dashboard tab from an active session, the sidebar is now restored and the AI panel is hidden