### PR TITLE
fix: isolate AI agent state and terminal handle per session tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { AppLayout } from '@/presentation/layouts'
 import { Dashboard, Settings } from '@/presentation/pages'
 import { ActiveSession } from '@/presentation/pages/ActiveSession'
-import { useSessionStore, useUIStore } from '@/application/stores'
+import { useSessionStore, useUIStore, useAIStore } from '@/application/stores'
 import { sessionRepository } from '@/infrastructure/repositories'
 
 interface SessionError {
@@ -45,11 +45,13 @@ function AppContent() {
       // Normal exit (user typed `exit`) — silently close the tab
       sessionRepository.disconnect(sessionId).catch(() => {})
       removeSession(sessionId)
+      useAIStore.getState().removeSession(sessionId)
     } else {
       // Unexpected close — show error popup, then close tab
       setSessionError({ sessionId, hostLabel, exitCode })
       sessionRepository.disconnect(sessionId).catch(() => {})
       removeSession(sessionId)
+      useAIStore.getState().removeSession(sessionId)
     }
   }, [removeSession])
 

--- a/src/application/hooks/useAIAgent.test.ts
+++ b/src/application/hooks/useAIAgent.test.ts
@@ -4,9 +4,11 @@ import { useAIAgent } from './useAIAgent'
 import { useAIStore, useSettingsStore } from '@/application/stores'
 import { DEFAULT_SETTINGS } from '@/domain/entities'
 
+const TEST_SESSION = 'test-session-1'
+
 describe('useAIAgent', () => {
   beforeEach(() => {
-    useAIStore.setState({ messages: [], isStreaming: false, error: null, executionMode: 'manual' })
+    useAIStore.setState({ sessions: new Map() })
     useSettingsStore.setState({
       settings: { ...DEFAULT_SETTINGS },
       openRouterApiKey: null,
@@ -21,7 +23,7 @@ describe('useAIAgent', () => {
   })
 
   it('should report error when no API key is configured', async () => {
-    const { result } = renderHook(() => useAIAgent())
+    const { result } = renderHook(() => useAIAgent(TEST_SESSION))
 
     await act(async () => {
       await result.current.sendMessage('Hello AI')
@@ -42,7 +44,7 @@ describe('useAIAgent', () => {
       new Response(JSON.stringify(mockResponse), { status: 200 }),
     )
 
-    const { result } = renderHook(() => useAIAgent())
+    const { result } = renderHook(() => useAIAgent(TEST_SESSION))
 
     await act(async () => {
       await result.current.sendMessage('Hello AI')
@@ -62,7 +64,7 @@ describe('useAIAgent', () => {
       new Response('Unauthorized', { status: 401 }),
     )
 
-    const { result } = renderHook(() => useAIAgent())
+    const { result } = renderHook(() => useAIAgent(TEST_SESSION))
 
     await act(async () => {
       await result.current.sendMessage('Hello')
@@ -80,7 +82,7 @@ describe('useAIAgent', () => {
     const pending = new Promise<Response>((r) => { resolveResponse = r })
     vi.spyOn(global, 'fetch').mockReturnValueOnce(pending)
 
-    const { result } = renderHook(() => useAIAgent())
+    const { result } = renderHook(() => useAIAgent(TEST_SESSION))
 
     const sendPromise = act(async () => {
       // do not await yet
@@ -101,7 +103,7 @@ describe('useAIAgent', () => {
       new Response(JSON.stringify({ choices: [{ message: { content: 'hi' } }] }), { status: 200 }),
     )
 
-    const { result } = renderHook(() => useAIAgent())
+    const { result } = renderHook(() => useAIAgent(TEST_SESSION))
 
     await act(async () => {
       await result.current.sendMessage('Hello')
@@ -113,6 +115,25 @@ describe('useAIAgent', () => {
     })
 
     expect(result.current.messages).toHaveLength(0)
+  })
+
+  it('should keep AI state isolated between different session IDs', async () => {
+    useSettingsStore.setState({ openRouterApiKey: 'sk-test-key' })
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ choices: [{ message: { content: 'reply for session 1' } }] }), { status: 200 }),
+    )
+
+    const { result: result1 } = renderHook(() => useAIAgent('session-1'))
+    const { result: result2 } = renderHook(() => useAIAgent('session-2'))
+
+    await act(async () => {
+      await result1.current.sendMessage('Message for session 1')
+    })
+
+    // session-1 should have messages; session-2 should still be empty
+    expect(result1.current.messages).toHaveLength(2)
+    expect(result2.current.messages).toHaveLength(0)
   })
 })
 

--- a/src/application/hooks/useAIAgent.ts
+++ b/src/application/hooks/useAIAgent.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { useAIStore, useSettingsStore } from '@/application/stores'
+import { DEFAULT_SESSION_STATE } from '@/application/stores'
+import type { ExecutionMode } from '@/application/stores'
 import type { AIMessage, AIRule } from '@/domain/entities'
 import { SendAIMessage } from '@/domain/usecases'
 import { OpenRouterClient } from '@/infrastructure/api'
@@ -48,16 +50,38 @@ function extractReadFilePaths(content: string): string[] {
 }
 
 /**
+ * sessionId: the active SSH session this agent is scoped to.
+ *   Pass null/undefined when there is no active session (agent is disabled).
  * onRunCommand: runs a shell command and returns its terminal output.
  * onReadFile: reads a remote file via SFTP and returns its content.
  * Passing these lets the agent see results and continue autonomously.
  */
 export function useAIAgent(
+  sessionId: string | null | undefined,
   onRunCommand?: (cmd: string) => Promise<string>,
   onReadFile?: (path: string) => Promise<string>,
   hostRules?: AIRule[],
 ) {
-  const { messages, isStreaming, error, addMessage, setStreaming, setError, clearMessages, executionMode, setExecutionMode } = useAIStore()
+  // Derive per-session state reactively so the hook re-renders only when this
+  // session's slice changes (not when other tabs' AI state changes).
+  // IMPORTANT: fall back to the stable DEFAULT_SESSION_STATE constant (not an
+  // inline object literal) so Zustand's snapshot comparison doesn't see a new
+  // reference every render, which would cause an infinite update loop.
+  const { messages, isStreaming, error, executionMode } = useAIStore((s) =>
+    (sessionId ? s.sessions.get(sessionId) : undefined) ?? DEFAULT_SESSION_STATE,
+  )
+
+  // Use getState() for actions — they are stable references and don't need
+  // to trigger re-renders, so we avoid adding the whole store to the selector.
+  const storeActions = useAIStore
+
+  // Bound action helpers that always scope to the current sessionId.
+  const addMessage    = useCallback((msg: AIMessage) => { if (sessionId) storeActions.getState().addMessage(sessionId, msg) }, [storeActions, sessionId])
+  const setStreaming   = useCallback((v: boolean)     => { if (sessionId) storeActions.getState().setStreaming(sessionId, v) }, [storeActions, sessionId])
+  const setError       = useCallback((e: string|null) => { if (sessionId) storeActions.getState().setError(sessionId, e) }, [storeActions, sessionId])
+  const clearMessages  = useCallback(()               => { if (sessionId) storeActions.getState().clearMessages(sessionId) }, [storeActions, sessionId])
+  const setExecutionMode = useCallback((mode: ExecutionMode) => { if (sessionId) storeActions.getState().setExecutionMode(sessionId, mode) }, [storeActions, sessionId])
+
   const { settings, openRouterApiKey } = useSettingsStore()
   const abortRef = useRef<AbortController | null>(null)
 

--- a/src/application/stores/aiStore.ts
+++ b/src/application/stores/aiStore.ts
@@ -3,32 +3,76 @@ import type { AIMessage } from '@/domain/entities'
 
 export type ExecutionMode = 'manual' | 'auto'
 
-interface AIState {
+/** State tracked independently for each open session/tab. */
+export interface PerSessionAIState {
   messages: AIMessage[]
   isStreaming: boolean
   error: string | null
   executionMode: ExecutionMode
 }
 
-interface AIActions {
-  addMessage: (message: AIMessage) => void
-  setStreaming: (streaming: boolean) => void
-  setError: (error: string | null) => void
-  clearMessages: () => void
-  setExecutionMode: (mode: ExecutionMode) => void
-}
-
-export type AIStore = AIState & AIActions
-
-export const useAIStore = create<AIStore>((set) => ({
+export const DEFAULT_SESSION_STATE: PerSessionAIState = {
   messages: [],
   isStreaming: false,
   error: null,
   executionMode: 'manual',
-  addMessage: (message) =>
-    set((state) => ({ messages: [...state.messages, message] })),
-  setStreaming: (isStreaming) => set({ isStreaming }),
-  setError: (error) => set({ error }),
-  clearMessages: () => set({ messages: [], error: null }),
-  setExecutionMode: (executionMode) => set({ executionMode }),
+}
+
+interface AIState {
+  /** Per-session AI state keyed by sessionId. */
+  sessions: Map<string, PerSessionAIState>
+}
+
+interface AIActions {
+  addMessage: (sessionId: string, message: AIMessage) => void
+  setStreaming: (sessionId: string, streaming: boolean) => void
+  setError: (sessionId: string, error: string | null) => void
+  clearMessages: (sessionId: string) => void
+  setExecutionMode: (sessionId: string, mode: ExecutionMode) => void
+  /** Remove all AI state for a session when the connection is closed. */
+  removeSession: (sessionId: string) => void
+  /** Returns the AI state for a session, creating default state if absent. */
+  getSessionState: (sessionId: string) => PerSessionAIState
+}
+
+export type AIStore = AIState & AIActions
+
+function updateSession(
+  state: AIState,
+  sessionId: string,
+  updater: (s: PerSessionAIState) => Partial<PerSessionAIState>,
+): Pick<AIState, 'sessions'> {
+  const sessions = new Map(state.sessions)
+  const current = sessions.get(sessionId) ?? { ...DEFAULT_SESSION_STATE }
+  sessions.set(sessionId, { ...current, ...updater(current) })
+  return { sessions }
+}
+
+export const useAIStore = create<AIStore>((set, get) => ({
+  sessions: new Map(),
+
+  addMessage: (sessionId, message) =>
+    set((state) => updateSession(state, sessionId, (s) => ({ messages: [...s.messages, message] }))),
+
+  setStreaming: (sessionId, isStreaming) =>
+    set((state) => updateSession(state, sessionId, () => ({ isStreaming }))),
+
+  setError: (sessionId, error) =>
+    set((state) => updateSession(state, sessionId, () => ({ error }))),
+
+  clearMessages: (sessionId) =>
+    set((state) => updateSession(state, sessionId, () => ({ messages: [], error: null }))),
+
+  setExecutionMode: (sessionId, executionMode) =>
+    set((state) => updateSession(state, sessionId, () => ({ executionMode }))),
+
+  removeSession: (sessionId) =>
+    set((state) => {
+      const sessions = new Map(state.sessions)
+      sessions.delete(sessionId)
+      return { sessions }
+    }),
+
+  getSessionState: (sessionId) =>
+    get().sessions.get(sessionId) ?? { ...DEFAULT_SESSION_STATE },
 }))

--- a/src/application/stores/index.ts
+++ b/src/application/stores/index.ts
@@ -6,8 +6,8 @@ export type { SessionStore } from './sessionStore'
 
 export { useTransferStore } from './transferStore'
 
-export { useAIStore } from './aiStore'
-export type { AIStore, ExecutionMode } from './aiStore'
+export { useAIStore, DEFAULT_SESSION_STATE } from './aiStore'
+export type { AIStore, ExecutionMode, PerSessionAIState } from './aiStore'
 
 export { useUIStore } from './uiStore'
 export type { UIStore } from './uiStore'

--- a/src/application/stores/terminalStore.ts
+++ b/src/application/stores/terminalStore.ts
@@ -13,18 +13,42 @@ export interface TerminalHandle {
 }
 
 interface TerminalStoreState {
-  /** The handle of the currently active terminal pane. Written by ActiveSession, read by AppLayout. */
-  activeTerminalHandle: TerminalHandle | null
+  /**
+   * One handle per session. All ActiveSession panes stay mounted (to preserve
+   * terminal scrollback), so we key by sessionId instead of keeping a single
+   * "active" reference — otherwise the last-mounted session would always win.
+   */
+  handles: Map<string, TerminalHandle>
 }
 
 interface TerminalStoreActions {
-  setActiveTerminalHandle: (handle: TerminalHandle | null) => void
+  /** Called by ActiveSession when its TerminalPane ref is set. */
+  registerHandle: (sessionId: string, handle: TerminalHandle) => void
+  /** Called by ActiveSession cleanup when the component unmounts. */
+  unregisterHandle: (sessionId: string) => void
+  /** Returns the handle for a specific session (undefined if not yet mounted). */
+  getHandle: (sessionId: string) => TerminalHandle | undefined
 }
 
 export type TerminalStore = TerminalStoreState & TerminalStoreActions
 
-export const useTerminalStore = create<TerminalStore>((set) => ({
-  activeTerminalHandle: null,
-  setActiveTerminalHandle: (handle) => set({ activeTerminalHandle: handle }),
+export const useTerminalStore = create<TerminalStore>((set, get) => ({
+  handles: new Map(),
+
+  registerHandle: (sessionId, handle) =>
+    set((state) => {
+      const handles = new Map(state.handles)
+      handles.set(sessionId, handle)
+      return { handles }
+    }),
+
+  unregisterHandle: (sessionId) =>
+    set((state) => {
+      const handles = new Map(state.handles)
+      handles.delete(sessionId)
+      return { handles }
+    }),
+
+  getHandle: (sessionId) => get().handles.get(sessionId),
 }))
 

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode, CSSProperties } from 'react'
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/core'
-import { useHostStore, useSessionStore, useUIStore, useSettingsStore, useTerminalStore } from '@/application/stores'
+import { useHostStore, useSessionStore, useUIStore, useSettingsStore, useTerminalStore, useAIStore } from '@/application/stores'
 import { useHost, useSession, useAIAgent, useVault } from '@/application/hooks'
 import { hostRepository, sessionRepository, vaultRepository } from '@/infrastructure/repositories'
 import { AddHostModal } from '@/presentation/components/sidebar'
@@ -37,7 +37,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   const { openSettings } = useUIStore()
   const { hosts: allHosts } = useHostStore()
   const { sessions, activeSessionId, setActiveSession } = useSessionStore()
-  const { activeTerminalHandle } = useTerminalStore()
+  const getTerminalHandle = useTerminalStore((s) => s.getHandle)
+
+  // Resolve the terminal handle for the currently active session.
+  // Because all ActiveSession panes stay mounted, we must look up by sessionId
+  // rather than relying on a single shared handle reference.
+  const activeTerminalHandle = activeSessionId ? getTerminalHandle(activeSessionId) ?? null : null
 
   // For manual Run button clicks in the AI chat UI — fire and forget
   const onRunCommand = useCallback((cmd: string) => {
@@ -68,11 +73,20 @@ export function AppLayout({ children }: AppLayoutProps) {
     return s ? allHosts.find((h) => h.id === s.hostId) ?? null : null
   }, [activeSessionId, sessions, allHosts])
 
-  const { messages, isStreaming, error, sendMessage, abort, clearMessages, executionMode, setExecutionMode } = useAIAgent(agentRunCommand, agentReadFile, activeHostForRules?.aiRules)
+  const { messages, isStreaming, error, sendMessage, abort, clearMessages, executionMode, setExecutionMode } = useAIAgent(activeSessionId, agentRunCommand, agentReadFile, activeHostForRules?.aiRules)
   const { loadApiKey, isApiKeyLoaded } = useSettingsStore()
   const { hosts, saveHost } = useHost(hostRepository)
   const { connectHost, disconnectSession } = useSession(sessionRepository)
   const { loadVault } = useVault(vaultRepository)
+
+  // Wraps disconnectSession to also clean up the per-session AI state.
+  const handleDisconnect = useCallback(
+    async (sessionId: string) => {
+      await disconnectSession(sessionId)
+      useAIStore.getState().removeSession(sessionId)
+    },
+    [disconnectSession],
+  )
 
   const handleUpdateHostRules = useCallback(
     (rules: AIRule[]) => {
@@ -223,7 +237,7 @@ export function AppLayout({ children }: AppLayoutProps) {
                     {(host?.label ?? host?.hostname ?? session.hostId).toUpperCase()}
                   </button>
                   <button
-                    onClick={() => disconnectSession(session.id)}
+                    onClick={() => handleDisconnect(session.id)}
                     className="px-1 h-[44px] opacity-0 group-hover:opacity-50 hover:!opacity-100 transition-opacity"
                     aria-label="Close session"
                     style={{ color: '#8a9bb0' }}

--- a/src/presentation/pages/ActiveSession.tsx
+++ b/src/presentation/pages/ActiveSession.tsx
@@ -37,17 +37,24 @@ export function ActiveSession({ sessionId, onClosed }: ActiveSessionProps) {
   const { sessions } = useSessionStore()
   const { hosts }    = useHostStore()
   const [activeTab, setActiveTab] = useState<ContentTab>('terminal')
-  const setActiveTerminalHandle = useTerminalStore((s) => s.setActiveTerminalHandle)
+  const { registerHandle, unregisterHandle } = useTerminalStore()
 
-  // Callback ref: registers the terminal handle in the global store when the pane mounts
+  // Callback ref: registers this session's terminal handle keyed by sessionId.
+  // All ActiveSession panes remain mounted (to preserve scrollback), so we
+  // must key by sessionId — otherwise the last-mounted session would overwrite
+  // the single shared handle and the AI agent would target the wrong tab.
   const handleTerminalRef = useCallback((handle: TerminalPaneHandle | null) => {
-    setActiveTerminalHandle(handle)
-  }, [setActiveTerminalHandle])
+    if (handle) {
+      registerHandle(sessionId, handle)
+    } else {
+      unregisterHandle(sessionId)
+    }
+  }, [sessionId, registerHandle, unregisterHandle])
 
-  // Clear the handle when this session unmounts
+  // Unregister when this session's component is fully unmounted.
   useEffect(() => {
-    return () => setActiveTerminalHandle(null)
-  }, [setActiveTerminalHandle])
+    return () => unregisterHandle(sessionId)
+  }, [sessionId, unregisterHandle])
 
   const activeSession = sessions.get(sessionId)
   const activeHost    = activeSession ? hosts.find((h) => h.id === activeSession.hostId) : null


### PR DESCRIPTION
## Problem

When multiple SSH tabs were open, the AI agent always targeted the **last-opened tab** instead of the currently active one. This happened because:

- `terminalStore` held a single `activeTerminalHandle` — since all `ActiveSession` panes stay mounted (to preserve scrollback), each one overwrote the same slot on mount, so the last-mounted session always won. Switching tabs never updated it.
- `aiStore` held one global `messages / isStreaming / error / executionMode`, so every open tab shared the same AI conversation.

## Solution

Each session now owns its own terminal handle and AI state.

### Changes

| File | What changed |
|---|---|
| `src/application/stores/terminalStore.ts` | Replace single `activeTerminalHandle` with `Map<sessionId, TerminalHandle>`. Expose `registerHandle` / `unregisterHandle` / `getHandle`. |
| `src/application/stores/aiStore.ts` | Replace flat state with `Map<sessionId, PerSessionAIState>` — each tab has its own messages, streaming flag, error and execution mode. Export `DEFAULT_SESSION_STATE`. |
| `src/application/hooks/useAIAgent.ts` | First argument is now `sessionId`. Uses stable `DEFAULT_SESSION_STATE` fallback in the Zustand selector to prevent infinite re-render loop. Actions dispatched via `getState()`. |
| `src/presentation/pages/ActiveSession.tsx` | Registers terminal handle by `sessionId` instead of overwriting a shared slot. |
| `src/presentation/layouts/AppLayout.tsx` | Derives `activeTerminalHandle` via `getHandle(activeSessionId)`; passes `activeSessionId` to `useAIAgent`; adds `handleDisconnect` wrapper to clean up per-session AI state on tab close. |
| `src/App.tsx` | Cleans up per-session AI state when a session closes via terminal exit. |
| `src/application/hooks/useAIAgent.test.ts` | Updated for new hook signature; added isolation test asserting two concurrent sessions don't bleed state. |