### PR TITLE
fix: resolve SSH private key authentication failures (Ed25519/OpenSSH)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +185,23 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bit-set"
@@ -197,12 +255,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -379,6 +456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +514,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +557,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -551,6 +664,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +736,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,7 +886,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -844,6 +1016,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1149,22 @@ checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1216,6 +1458,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1263,6 +1506,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1362,6 +1615,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1718,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1741,6 +2014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2247,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2201,10 +2499,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2213,6 +2547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2376,6 +2711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2733,44 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
 
 [[package]]
 name = "pango"
@@ -2439,6 +2818,24 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2641,6 +3038,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +3088,29 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2736,6 +3177,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3062,6 +3512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3572,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3236,6 +3717,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3515,6 +4010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,6 +4114,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ssh2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3631,6 +4203,7 @@ dependencies = [
  "mockall",
  "serde",
  "serde_json",
+ "ssh-key",
  "ssh2",
  "tauri",
  "tauri-build",
@@ -3702,6 +4275,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4569,6 +5148,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,9 @@ tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["full"] }
 ssh2 = "0.9"
+# Pure-Rust SSH key parsing — handles OpenSSH format (Ed25519 etc.) that
+# libssh2/OpenSSL cannot reliably parse on all platforms.
+ssh-key = { version = "0.6", features = ["ed25519", "rsa", "ecdsa", "encryption", "std"] }
 uuid = { version = "1", features = ["v4"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 thiserror = "2"

--- a/src-tauri/src/infrastructure/ssh/mod.rs
+++ b/src-tauri/src/infrastructure/ssh/mod.rs
@@ -5,3 +5,61 @@ pub mod ssh_manager;
 
 pub use sftp_worker::{SftpCommand, TransferProgress};
 pub use ssh_manager::SshManager;
+
+/// Reads a private key file and converts it to a PEM string that libssh2's
+/// OpenSSL backend can handle via `userauth_pubkey_memory`.
+///
+/// The root problem: libssh2 bundles its own OpenSSH private key parser but its
+/// bcrypt KDF implementation fails to decrypt Ed25519 (and other modern)
+/// OpenSSH-format keys on some macOS/OpenSSL builds.  We work around this by
+/// decrypting the key ourselves using the `ssh-key` pure-Rust crate, then
+/// re-serialising the key as an *unencrypted* OpenSSH armoured string.  libssh2\
+/// handles the unencrypted variant reliably; it only breaks on the bcrypt step.
+///
+/// Returns `(pem_for_libssh2, passphrase_for_libssh2)`.
+/// When we decrypt the key the returned passphrase is `None` (already consumed).
+/// For non-OpenSSH keys the file content and original passphrase are forwarded
+/// unchanged so libssh2 can handle them itself.
+pub fn decode_key_for_libssh2(
+    path: &str,
+    passphrase: Option<&str>,
+) -> Result<(String, Option<String>), String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("Could not read key file: {e}"))?;
+
+    // pem-rfc7468 (used by ssh-key) rejects any trailing bytes after the
+    // post-encapsulation boundary, including extra newlines.  Always trim.
+    let content = raw.trim();
+
+    // Only OpenSSH-armored keys need special handling.
+    if !content.contains("BEGIN OPENSSH PRIVATE KEY") {
+        return Ok((content.to_owned(), passphrase.map(str::to_owned)));
+    }
+
+    use ssh_key::PrivateKey;
+
+    let parsed = PrivateKey::from_openssh(content)
+        .map_err(|e| format!("Key parse error: {e}"))?;
+
+    let decrypted = if parsed.is_encrypted() {
+        let pp = passphrase.unwrap_or("");
+        if pp.is_empty() {
+            // Signal that a passphrase is needed — frontend will prompt the user.
+            return Err("bcrypted without passphrase".to_string());
+        }
+        parsed
+            .decrypt(pp.as_bytes())
+            .map_err(|_| "Private key unpack failed (correct password?)".to_string())?
+    } else {
+        parsed
+    };
+
+    // Re-serialise as **unencrypted** OpenSSH PEM.  libssh2 handles the
+    // unencrypted OpenSSH format reliably; it only breaks on bcrypt decryption.
+    let unencrypted_pem = decrypted
+        .to_openssh(Default::default())
+        .map_err(|e| format!("Key re-serialisation error: {e}"))?;
+
+    // Passphrase has been consumed by us — pass None to libssh2.
+    Ok((unencrypted_pem.to_string(), None))
+}

--- a/src-tauri/src/infrastructure/ssh/sftp_worker.rs
+++ b/src-tauri/src/infrastructure/ssh/sftp_worker.rs
@@ -1,6 +1,19 @@
 /// SftpWorker — a dedicated thread per SSH session that owns the ssh2 SFTP
 /// subsystem and processes file-operation commands sent through a channel.
 /// Using a dedicated thread avoids the `!Send` constraint of ssh2::Session.
+
+/// Ensures a key file ends with a Unix newline.
+/// libssh2's OpenSSH parser can silently mis-derive the public key from
+/// files that lack a trailing `\n`, causing server-side rejection errors.
+fn normalize_key_file(path: &str) {
+    if let Ok(bytes) = std::fs::read(path) {
+        if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
+            let mut fixed = bytes;
+            fixed.push(b'\n');
+            let _ = std::fs::write(path, fixed);
+        }
+    }
+}
 use ssh2::Session as Ssh2Session;
 use std::io::{Read, Write};
 use std::net::TcpStream;
@@ -127,9 +140,31 @@ fn sftp_thread(
                 return;
             }
             Some(path) => {
-                let pub_key = host.public_key_path.as_deref().map(Path::new);
+                normalize_key_file(path);
                 let passphrase = host.key_passphrase.as_deref();
-                ssh.userauth_pubkey_file(&host.username, pub_key, Path::new(path), passphrase)
+                eprintln!(
+                    "[SSHift SFTP] auth: user={} path={} has_passphrase={}",
+                    host.username, path, passphrase.is_some()
+                );
+                match crate::infrastructure::ssh::decode_key_for_libssh2(path, passphrase) {
+                    Err(decode_err) => {
+                        eprintln!("[SSHift SFTP] Key decode error: {decode_err}");
+                        let _ = result_tx.send(Err(format!("SFTP key decode: {decode_err}")));
+                        return;
+                    }
+                    Ok((key_pem, effective_passphrase)) => {
+                        let result = ssh.userauth_pubkey_memory(
+                            &host.username,
+                            None,
+                            &key_pem,
+                            effective_passphrase.as_deref(),
+                        );
+                        if let Err(ref e) = result {
+                            eprintln!("[SSHift SFTP] userauth_pubkey_memory FAILED: {e}");
+                        }
+                        result
+                    }
+                }
             }
         },
     };

--- a/src-tauri/src/infrastructure/ssh/ssh_manager.rs
+++ b/src-tauri/src/infrastructure/ssh/ssh_manager.rs
@@ -2,11 +2,23 @@
 /// Each session runs in its own std::thread that owns the ssh2 Session + Channel
 /// (solving ssh2's lifetime constraints). Commands are sent via SyncSender; output
 /// is streamed back to the frontend via Tauri events.
+
+/// Ensures a key file ends with a Unix newline.
+/// libssh2's OpenSSH parser can silently mis-derive the public key from
+/// files that lack a trailing `\n`, causing server-side rejection errors.
+fn normalize_key_file(path: &str) {
+    if let Ok(bytes) = std::fs::read(path) {
+        if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
+            let mut fixed = bytes;
+            fixed.push(b'\n');
+            let _ = std::fs::write(path, fixed);
+        }
+    }
+}
 use ssh2::Session as Ssh2Session;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TryRecvError};
 use std::time::{Duration, Instant};
@@ -239,9 +251,37 @@ fn connection_thread(
                 return;
             }
             Some(path) => {
-                let pub_key = host.public_key_path.as_deref().map(Path::new);
+                normalize_key_file(path);
                 let passphrase = host.key_passphrase.as_deref();
-                ssh.userauth_pubkey_file(&host.username, pub_key, Path::new(path), passphrase)
+                eprintln!(
+                    "[SSHift] auth: user={} path={} has_passphrase={}",
+                    host.username, path, passphrase.is_some()
+                );
+                match crate::infrastructure::ssh::decode_key_for_libssh2(path, passphrase) {
+                    Err(decode_err) => {
+                        eprintln!("[SSHift] Key decode error: {decode_err}");
+                        let _ = result_tx.send(Err(RepositoryError::AuthenticationFailed(
+                            format!("Auth failed for '{}': {decode_err}", host.username),
+                        )));
+                        return;
+                    }
+                    Ok((key_pem, effective_passphrase)) => {
+                        eprintln!(
+                            "[SSHift] Key decoded OK, passing to libssh2 (passphrase={})",
+                            effective_passphrase.is_some()
+                        );
+                        let result = ssh.userauth_pubkey_memory(
+                            &host.username,
+                            None,
+                            &key_pem,
+                            effective_passphrase.as_deref(),
+                        );
+                        if let Err(ref e) = result {
+                            eprintln!("[SSHift] userauth_pubkey_memory FAILED: {e}");
+                        }
+                        result
+                    }
+                }
             }
         },
     };

--- a/src/presentation/components/vault/VaultEntryForm.tsx
+++ b/src/presentation/components/vault/VaultEntryForm.tsx
@@ -35,7 +35,11 @@ export function VaultEntryForm({ isOpen, onClose, onSave }: VaultEntryFormProps)
     setError(null)
     setIsSaving(true)
     try {
-      await onSave(name.trim(), type, content.trim())
+      // Normalize line endings and ensure a trailing newline so libssh2 can
+      // reliably parse both RSA (PEM) and Ed25519 (OpenSSH) key files.
+      const normalizedContent =
+        content.trim().replace(/\r\n/g, '\n').replace(/\r/g, '\n') + '\n'
+      await onSave(name.trim(), type, normalizedContent)
       setName('')
       setContent('')
       setType('privateKey')

--- a/src/presentation/layouts/AppLayout.tsx
+++ b/src/presentation/layouts/AppLayout.tsx
@@ -14,7 +14,9 @@ import { hostRepository, sessionRepository, vaultRepository } from '@/infrastruc
 import { AddHostModal } from '@/presentation/components/sidebar'
 import { AIPanel } from '@/presentation/components/ai'
 import { CommandPalette } from '@/presentation/components/command'
-import { Button, Modal } from '@/presentation/shared'
+import { PassphraseModal } from '@/presentation/components/terminal'
+import { Button, Modal, isPassphraseError, formatSshError } from '@/presentation/shared'
+import { passphraseCache } from '@/infrastructure/passphraseCache'
 import { Vault } from '@/presentation/pages'
 import { APP_NAME } from '@/config'
 import type { Host, AIRule } from '@/domain/entities'
@@ -41,6 +43,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   const [pendingHost, setPendingHost] = useState<Host | null>(null)
   const [pendingPassword, setPendingPassword] = useState('')
   const [showPendingPw, setShowPendingPw] = useState(false)
+
+  // Private-key passphrase prompt
+  const [passphraseHost, setPassphraseHost] = useState<Host | null>(null)
+  const [passphraseConnecting, setPassphraseConnecting] = useState(false)
 
   const { openSettings } = useUIStore()
   const { isCommandPaletteOpen, openCommandPalette, closeCommandPalette } = useUIStore()
@@ -150,16 +156,48 @@ export function AppLayout({ children }: AppLayoutProps) {
       }
       setConnectError(null)
       try {
-        await connectHost(host)
+        const cachedPassphrase = host.vaultEntryId ? passphraseCache.get(host.vaultEntryId) : undefined
+        await connectHost(cachedPassphrase ? { ...host, keyPassphrase: cachedPassphrase } : host)
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        const debug = `[${host.username}@${host.hostname}:${host.port} auth=${host.authMethod}${host.vaultEntryId ? ' vault=' + host.vaultEntryId : ''}${host.password ? ' pw=***' : ''}]`
-        setConnectError(`${msg}\n${debug}`)
-        if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-        errorTimerRef.current = setTimeout(() => setConnectError(null), 10000)
+        const rawErr = err instanceof Error ? err.message : String(err)
+        console.error('[SSHift] connect error (raw):', rawErr)
+        if (isPassphraseError(rawErr)) {
+          setPassphraseHost(host)
+        } else {
+          setConnectError(`${formatSshError(rawErr)}\n${rawErr.slice(0, 160)}`)
+          if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+          errorTimerRef.current = setTimeout(() => setConnectError(null), 10000)
+        }
       }
     },
     [connectHost, sessions, setActiveSession],
+  )
+
+  const handlePassphraseSubmit = useCallback(
+    async (passphrase: string) => {
+      if (!passphraseHost) return
+      const host = passphraseHost
+      if (host.vaultEntryId) passphraseCache.set(host.vaultEntryId, passphrase)
+      setPassphraseHost(null)
+      try {
+        setPassphraseConnecting(true)
+        await connectHost({ ...host, keyPassphrase: passphrase })
+      } catch (err) {
+        const rawErr = err instanceof Error ? err.message : String(err)
+        console.error('[SSHift] passphrase connect error (raw):', rawErr)
+        if (host.vaultEntryId && isPassphraseError(rawErr)) {
+          passphraseCache.clear(host.vaultEntryId)
+          setConnectError('Incorrect passphrase. Please try connecting again.')
+        } else {
+          setConnectError(`${formatSshError(rawErr)}\n${rawErr.slice(0, 160)}`)
+        }
+        if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+        errorTimerRef.current = setTimeout(() => setConnectError(null), 10000)
+      } finally {
+        setPassphraseConnecting(false)
+      }
+    },
+    [passphraseHost, connectHost],
   )
 
   // Called from the password-prompt modal
@@ -477,6 +515,15 @@ export function AppLayout({ children }: AppLayoutProps) {
           onClose={() => setIsAddHostOpen(false)}
           onSave={saveHost}
         />
+        {passphraseHost && (
+          <PassphraseModal
+            hostname={passphraseHost.hostname}
+            username={passphraseHost.username}
+            isConnecting={passphraseConnecting}
+            onConfirm={handlePassphraseSubmit}
+            onCancel={() => setPassphraseHost(null)}
+          />
+        )}
         <CommandPalette
           isOpen={isCommandPaletteOpen}
           onClose={closeCommandPalette}
@@ -690,6 +737,15 @@ export function AppLayout({ children }: AppLayoutProps) {
         onClose={() => setIsAddHostOpen(false)}
         onSave={saveHost}
       />
+      {passphraseHost && (
+        <PassphraseModal
+          hostname={passphraseHost.hostname}
+          username={passphraseHost.username}
+          isConnecting={passphraseConnecting}
+          onConfirm={handlePassphraseSubmit}
+          onCancel={() => setPassphraseHost(null)}
+        />
+      )}
       <CommandPalette
         isOpen={isCommandPaletteOpen}
         onClose={closeCommandPalette}

--- a/src/presentation/pages/Dashboard.tsx
+++ b/src/presentation/pages/Dashboard.tsx
@@ -40,7 +40,7 @@ export function Dashboard() {
         if (isPassphraseError(rawErr)) {
           setPassphraseHost(host)
         } else {
-          setConnectError(formatSshError(rawErr))
+          setConnectError(`${formatSshError(rawErr)}\n${rawErr.slice(0, 160)}`)
         }
       } finally {
         setConnectingId(null)
@@ -71,7 +71,7 @@ export function Dashboard() {
           passphraseCache.clear(host.vaultEntryId)
           setConnectError('Incorrect passphrase. Please try connecting again.')
         } else {
-          setConnectError(formatSshError(rawErr))
+          setConnectError(`${formatSshError(rawErr)}\n${rawErr.slice(0, 160)}`)
         }
       } finally {
         setPassphraseConnecting(false)

--- a/src/presentation/shared/Toast.tsx
+++ b/src/presentation/shared/Toast.tsx
@@ -23,8 +23,18 @@ export function Toast({ message, type, onDismiss }: ToastProps) {
   return (
     <div
       className={`fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-lg border px-4 py-3 shadow-lg ${typeClasses[type]}`}
+      style={{ maxWidth: '480px' }}
     >
-      <span className="text-sm">{message}</span>
+      <span className="flex flex-col gap-0.5">
+        <span className="text-sm">{message.split('\n')[0]}</span>
+        {message.includes('\n') && (
+          <span
+            className="text-[0.65rem] opacity-60 font-mono break-all"
+          >
+            {message.split('\n')[1]}
+          </span>
+        )}
+      </span>
       <button
         onClick={onDismiss}
         className="ml-2 opacity-70 hover:opacity-100 transition-opacity"

--- a/src/presentation/shared/formatSshError.ts
+++ b/src/presentation/shared/formatSshError.ts
@@ -1,10 +1,20 @@
 /**
  * Returns true when the raw error string indicates the private key is
  * passphrase-protected and the passphrase was not supplied (or was wrong).
- * libssh2 reports this as "Callback returned error" with session code -19.
+ *
+ * libssh2 reports different errors depending on the key type and backend:
+ *  - RSA/PEM keys      : "Callback returned error" (Session -19, LIBSSH2_ERROR_DECRYPT)
+ *  - Ed25519/OpenSSH   : "bcrypted without passphrase" when no passphrase given
+ *                        "Private key unpack failed (correct password?)" when wrong passphrase
+ *                        Both map to Session -48 (LIBSSH2_ERROR_KEYFILE_AUTH_FAILED)
  */
 export function isPassphraseError(raw: string): boolean {
-  return /callback returned error/i.test(raw)
+  return (
+    /callback returned error/i.test(raw) ||
+    /bcrypted without passphrase/i.test(raw) ||
+    /private key unpack failed/i.test(raw) ||
+    /\[Session\(-48\)\]/i.test(raw)
+  )
 }
 
 /**
@@ -29,14 +39,39 @@ export function formatSshError(raw: string): string {
 
   // ── Authentication failures ────────────────────────────────────────────────
   if (/authentication failed/i.test(msg) || /auth failed/i.test(msg)) {
-    // libssh2 "Callback returned error" means it couldn't read/parse the key file
+    // libssh2 "Callback returned error" — RSA/PEM key passphrase issue
     if (/callback returned error/i.test(msg)) {
       return 'Could not read the private key file. The key may be passphrase-protected, corrupted, or in an unsupported format.'
     }
-    // "disconnect" or "Permission denied" from the server
-    if (/permission denied/i.test(msg) || /publickey/i.test(msg)) {
+    // Ed25519/OpenSSH bcrypt key: no passphrase supplied
+    if (/bcrypted without passphrase/i.test(msg)) {
+      return 'This key requires a passphrase. Please re-connect and enter the passphrase when prompted.'
+    }
+    // Ed25519/OpenSSH bcrypt key: passphrase was wrong (Session -48)
+    if (/private key unpack failed/i.test(msg) || /\[Session\(-48\)\]/i.test(msg)) {
+      return 'Incorrect passphrase for the private key. Please try connecting again.'
+    }
+    // Server-side rejection:
+    //  - LIBSSH2_ERROR_AUTHENTICATION_FAILED (-14): probe rejected / final FAILURE
+    //    → messages: "Username/PublicKey combination invalid"
+    //                or fallback "authentication failed" (from ssh2-rs from_errno)
+    //  - LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED (-19): signing callback failed or
+    //    server rejected signed packet
+    //    → messages: "Invalid signature for supplied public key, or bad username/public key combination"
+    //                "public key unverified" (from ssh2-rs from_errno)
+    //                "Callback returned error" (signing callback failure)
+    //  Also catch "Permission denied, publickey" from OpenSSH servers.
+    if (
+      /\[Session\(-(?:14|19)\)\]/i.test(msg) ||
+      /permission denied/i.test(msg) ||
+      /publickey/i.test(msg) ||
+      /public[\s_]?key/i.test(msg) ||
+      /invalid signature/i.test(msg) ||
+      /username\/public/i.test(msg)
+    ) {
       return "The server rejected the key. Make sure the correct public key is added to the server's authorized_keys."
     }
+    // Password authentication failed
     if (/password/i.test(msg)) {
       return 'Incorrect password. Please check your credentials and try again.'
     }


### PR DESCRIPTION
## Problem

Connecting with Ed25519 private keys stored in the vault failed with a chain of errors:

1. `[Session(-48)] bcrypted without passphrase` — passphrase modal never shown for Ed25519 keys
2. `[Session(-16)] Unable to extract public key from private key file: Unsupported private key file format` — libssh2's bcrypt KDF implementation can't decrypt OpenSSH-format keys on this macOS/OpenSSL build
3. `PEM error in pre-encapsulation boundary` — extra trailing `\n` appended to vault key files broke strict PEM parsing

## Root Causes

- **libssh2 can't decrypt bcrypt-KDF Ed25519 keys** on macOS with certain OpenSSL builds. The `BEGIN OPENSSH PRIVATE KEY` format is parsed by libssh2's own C implementation which fails at the bcrypt decryption step.
- **`isPassphraseError()`** only matched RSA passphrase patterns, missing Ed25519-specific error strings (`Session(-48)`, `bcrypted without passphrase`, `Private key unpack failed`).
- **`AppLayout.handleConnect`** (sidebar connections) had no passphrase prompting at all — only `Dashboard.tsx` did.
- **Vault key files** were missing trailing newlines, then the fix over-appended causing `\n\n` endings which broke `pem-rfc7468`.

## Fix

### Rust (`src-tauri`)
- Added **`ssh-key` crate** — pure-Rust bcrypt KDF implementation correctly handles all Ed25519/OpenSSH encrypted keys
- New **`decode_key_for_libssh2()`** helper in `mod.rs`:
  1. Detects `BEGIN OPENSSH PRIVATE KEY` files
  2. Trims content to avoid `pem-rfc7468` strict parsing failures  
  3. Decrypts the key entirely in Rust using `ssh-key`'s bcrypt impl
  4. Re-serialises as **unencrypted** OpenSSH PEM — libssh2 handles this reliably
  5. Passes `None` passphrase to libssh2 (already consumed)
  6. Non-OpenSSH keys (RSA PEM) pass through unchanged
- `normalize_key_file()` helper ensures vault key files have exactly one trailing newline
- Both `ssh_manager.rs` and `sftp_worker.rs` use the new in-memory auth path with diagnostic `eprintln!` logging

### TypeScript (`src/`)
- **`formatSshError.ts`**: `isPassphraseError()` now catches `Session(-48)`, `bcrypted without passphrase`, `Private key unpack failed`
- **`AppLayout.tsx`**: `handleConnect` now detects passphrase errors and shows `PassphraseModal` — consistent with `Dashboard.tsx`
- **`VaultEntryForm.tsx`**: Normalises key content on save (trim + LF line endings + single trailing newline)
- **`Toast.tsx`**: Renders second line of error messages in monospace for raw libssh2 error visibility
- **`Dashboard.tsx`**: Shows raw error string as diagnostic second line in error banner