### PR TITLE
fix: AI Agent "Load failed" error in macOS release build

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://api.anthropic.com; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; connect-src 'self' https://api.anthropic.com https://openrouter.ai; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Bug Fix: Shift AI Agent "Load failed" on macOS Release Build

### Problem

The AI Agent panel was failing with a `TypeError: Load failed` error in the distributed macOS `.dmg` build. The feature worked correctly during development (`npm run app`) but broke in production.

**Root cause:** Tauri's Content Security Policy (CSP) was missing `https://openrouter.ai` from the `connect-src` directive. In development, the app is served from `http://localhost` so the CSP is not enforced by WKWebView. In the production app bundle, the app is served under the `tauri://localhost` scheme and the CSP is strictly applied — causing WKWebView to silently block all outbound `fetch()` requests to OpenRouter before they reached the network.

### Fix

Added `https://openrouter.ai` to `connect-src` in `src-tauri/tauri.conf.json`.

```diff
- "connect-src 'self' https://api.anthropic.com"
+ "connect-src 'self' https://api.anthropic.com https://openrouter.ai"
```

### Impact

- **Affected feature:** Shift AI Agent (all models served via OpenRouter)
- **Affected platform:** macOS release build only — dev builds were unaffected
- **Files changed:** `src-tauri/tauri.conf.json` (1 line)