### PR TITLE
fix: resolve SFTP file explorer list_dir failures

### DIFF
--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -54,10 +54,12 @@ fn read_local_dir(path: &str) -> Result<Vec<FileEntry>, String> {
         })
         .collect();
 
-    entries.sort_by(|a, b| match (&a.entry_type, &b.entry_type) {
-        (FileEntryType::Directory, FileEntryType::File) => std::cmp::Ordering::Less,
-        (FileEntryType::File, FileEntryType::Directory) => std::cmp::Ordering::Greater,
-        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    entries.sort_by_key(|e| {
+        let rank = match e.entry_type {
+            FileEntryType::Directory => 0,
+            _ => 1,
+        };
+        (rank, e.name.to_lowercase())
     });
 
     Ok(entries)

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -120,7 +120,17 @@ pub async fn list_remote_directory(
     tokio::task::spawn_blocking(move || {
         reply_rx
             .recv_timeout(std::time::Duration::from_secs(30))
-            .map_err(|_| "SFTP list_dir timed out".to_string())
+            .map_err(|e| match e {
+                std::sync::mpsc::RecvTimeoutError::Timeout => {
+                    "SFTP list_dir timed out: the remote server did not respond in 30 s. \
+                     Check your network connection or try reconnecting."
+                        .to_string()
+                }
+                std::sync::mpsc::RecvTimeoutError::Disconnected => {
+                    "SFTP worker disconnected unexpectedly. Please reconnect to the host."
+                        .to_string()
+                }
+            })
             .and_then(|r| r)
     })
     .await

--- a/src-tauri/src/infrastructure/ssh/sftp_worker.rs
+++ b/src-tauri/src/infrastructure/ssh/sftp_worker.rs
@@ -110,6 +110,7 @@ fn sftp_thread(
 ) {
     // ── TCP + SSH handshake ───────────────────────────────────────────────────
     let addr = format!("{}:{}", host.hostname, host.port);
+    eprintln!("[SSHift SFTP] connecting to {addr} for {}...", host.username);
     let tcp = match TcpStream::connect(&addr) {
         Ok(t) => t,
         Err(e) => {
@@ -186,18 +187,48 @@ fn sftp_thread(
 
     // ── Create command channel and signal success ─────────────────────────────
     let (cmd_tx, cmd_rx) = sync_channel::<SftpCommand>(128);
+    eprintln!("[SSHift SFTP] worker ready for {}@{}", host.username, host.hostname);
     let _ = result_tx.send(Ok(cmd_tx));
     // result_tx is dropped — don't touch it after this point
 
     // ── Event loop ────────────────────────────────────────────────────────────
     loop {
         match cmd_rx.recv() {
-            Ok(SftpCommand::Disconnect) | Err(_) => return,
+            Ok(SftpCommand::Disconnect) | Err(_) => {
+                eprintln!("[SSHift SFTP] worker exiting for {}@{}", host.username, host.hostname);
+                return;
+            }
 
             Ok(SftpCommand::Ping) => { /* no-op liveness check */ }
 
             Ok(SftpCommand::ListDir { path, reply }) => {
-                let _ = reply.send(sftp_list_dir(&sftp, &path));
+                eprintln!("[SSHift SFTP] ListDir: {path}");
+                // Wrap in catch_unwind so a libssh2 panic surfaces as an error
+                // rather than silently dropping the reply channel (Disconnected).
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    sftp_list_dir(&sftp, &path)
+                }));
+                match result {
+                    Ok(r) => {
+                        if let Err(ref e) = r {
+                            eprintln!("[SSHift SFTP] ListDir error: {e}");
+                        }
+                        let _ = reply.send(r);
+                    }
+                    Err(panic_val) => {
+                        let msg = if let Some(s) = panic_val.downcast_ref::<String>() {
+                            s.clone()
+                        } else if let Some(s) = panic_val.downcast_ref::<&str>() {
+                            s.to_string()
+                        } else {
+                            "unknown panic in sftp readdir".to_string()
+                        };
+                        eprintln!("[SSHift SFTP] ListDir PANICKED: {msg}");
+                        let _ = reply.send(Err(format!("SFTP readdir panicked: {msg}")));
+                        // SFTP state is undefined after a panic — exit the worker.
+                        return;
+                    }
+                }
             }
 
             Ok(SftpCommand::StatFile { path, reply }) => {
@@ -279,10 +310,15 @@ fn sftp_list_dir(sftp: &ssh2::Sftp, path: &str) -> Result<Vec<FileEntry>, String
         })
         .collect();
 
-    entries.sort_by(|a, b| match (&a.entry_type, &b.entry_type) {
-        (FileEntryType::Directory, FileEntryType::File) => std::cmp::Ordering::Less,
-        (FileEntryType::File, FileEntryType::Directory) => std::cmp::Ordering::Greater,
-        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    // Use sort_by_key for a guaranteed total order:
+    // directories first, then symlinks, then files; alphabetical within each group.
+    entries.sort_by_key(|e| {
+        let rank = match e.entry_type {
+            FileEntryType::Directory => 0,
+            FileEntryType::Symlink => 1,
+            FileEntryType::File => 2,
+        };
+        (rank, e.name.to_lowercase())
     });
 
     Ok(entries)

--- a/src-tauri/src/infrastructure/ssh/sftp_worker.rs
+++ b/src-tauri/src/infrastructure/ssh/sftp_worker.rs
@@ -117,11 +117,6 @@ fn sftp_thread(
             return;
         }
     };
-    // Bound blocking read calls so a stalled readdir doesn't hang indefinitely
-    // (e.g. when a silent NAT/firewall drop occurs on an idle connection).
-    if let Err(e) = tcp.set_read_timeout(Some(std::time::Duration::from_secs(60))) {
-        eprintln!("[SSHift SFTP] Warning: could not set TCP read timeout: {e}");
-    }
     let mut ssh = match Ssh2Session::new() {
         Ok(s) => s,
         Err(e) => {

--- a/src-tauri/src/infrastructure/ssh/sftp_worker.rs
+++ b/src-tauri/src/infrastructure/ssh/sftp_worker.rs
@@ -42,6 +42,8 @@ pub struct TransferProgress {
 // ── Commands ──────────────────────────────────────────────────────────────────
 
 pub enum SftpCommand {
+    /// No-op heartbeat — used to probe whether the worker thread is still alive.
+    Ping,
     ListDir {
         path: String,
         reply: SyncSender<Result<Vec<FileEntry>, String>>,
@@ -115,6 +117,11 @@ fn sftp_thread(
             return;
         }
     };
+    // Bound blocking read calls so a stalled readdir doesn't hang indefinitely
+    // (e.g. when a silent NAT/firewall drop occurs on an idle connection).
+    if let Err(e) = tcp.set_read_timeout(Some(std::time::Duration::from_secs(60))) {
+        eprintln!("[SSHift SFTP] Warning: could not set TCP read timeout: {e}");
+    }
     let mut ssh = match Ssh2Session::new() {
         Ok(s) => s,
         Err(e) => {
@@ -191,6 +198,8 @@ fn sftp_thread(
     loop {
         match cmd_rx.recv() {
             Ok(SftpCommand::Disconnect) | Err(_) => return,
+
+            Ok(SftpCommand::Ping) => { /* no-op liveness check */ }
 
             Ok(SftpCommand::ListDir { path, reply }) => {
                 let _ = reply.send(sftp_list_dir(&sftp, &path));

--- a/src-tauri/src/infrastructure/ssh/ssh_manager.rs
+++ b/src-tauri/src/infrastructure/ssh/ssh_manager.rs
@@ -159,7 +159,17 @@ impl SshManager {
             .ok_or_else(|| RepositoryError::NotFound(session_id.to_string()))?;
 
         if let Some(ref tx) = entry.sftp_tx {
-            return Ok(tx.clone());
+            // Probe liveness: if the worker thread has exited the SyncSender
+            // will return TrySendError::Disconnected.  Clear and re-spawn.
+            match tx.try_send(crate::infrastructure::ssh::SftpCommand::Ping) {
+                Ok(_) | Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                    return Ok(tx.clone());
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                    eprintln!("[SSHift] SFTP worker for session '{session_id}' has exited — restarting.");
+                    entry.sftp_tx = None;
+                }
+            }
         }
 
         // Spin up a new SFTP worker.

--- a/src/infrastructure/tauri/TauriFileRepository.ts
+++ b/src/infrastructure/tauri/TauriFileRepository.ts
@@ -4,7 +4,7 @@ import type { IFileRepository } from '@/domain/repositories'
 
 export class TauriFileRepository implements IFileRepository {
   async listDirectory(sessionId: string, path: string): Promise<FileEntry[]> {
-    const entries = await invoke<FileEntry[]>('list_directory', { sessionId, path })
+    const entries = await invoke<FileEntry[]>('list_remote_directory', { sessionId, path })
     return entries.map((entry) => ({
       ...entry,
       modifiedAt: new Date(entry.modifiedAt),


### PR DESCRIPTION
## Problem

Opening the SFTP file explorer always failed with either:
- `"SFTP list_dir timed out"` — the original reported error
- `"SFTP worker disconnected unexpectedly"` — after the error messaging improvement

## Root Causes

### 1. Wrong Tauri command name (critical)
`TauriFileRepository.listDirectory` was calling `invoke('list_directory', ...)` — a dead stub that immediately returns an error message. The real handler is `list_remote_directory`. Every single SFTP directory listing failed before even reaching the network.

### 2. Sort comparator panicking on symlinks
`sftp_list_dir` used `sort_by` with a partial comparator that only handled `(Directory, File)` / `(File, Directory)` pairs. On servers whose root contains symlinks (e.g. Ubuntu's `/bin → /usr/bin`), the comparator produced an inconsistent ordering, triggering Rust's panic:
> *"user-provided comparison function does not correctly implement a total order"*

The panic dropped the reply channel without sending a value, causing `RecvTimeoutError::Disconnected` on the caller side.

### 3. Stale cached `sftp_tx` after worker crash
If the SFTP worker thread exited, the cached `SyncSender<SftpCommand>` was still returned as-is. `send()` succeeded (channel buffer), but no receiver — the caller then waited 30 s before timing out.

## Changes

| File | Change |
|---|---|
| `src/infrastructure/tauri/TauriFileRepository.ts` | Invoke `list_remote_directory` (was `list_directory`) |
| `src-tauri/src/infrastructure/ssh/sftp_worker.rs` | Fix sort comparator; add `Ping` command; add `catch_unwind` around `readdir`; add lifecycle logging |
| `src-tauri/src/infrastructure/ssh/ssh_manager.rs` | Probe cached `sftp_tx` liveness with `try_send(Ping)` before reuse; clear and respawn if disconnected |
| `src-tauri/src/commands/file_commands.rs` | Fix same partial sort in local dir listing; improve `recv_timeout` error messages |
